### PR TITLE
pass custom container to mount mfe app

### DIFF
--- a/public/app/fn-app/create-mfe.ts
+++ b/public/app/fn-app/create-mfe.ts
@@ -59,7 +59,7 @@ type DeepPartial<T> = {
 
 class createMfe {
   private static readonly containerSelector = '#grafanaRoot';
-  private static themeStyleRoot: MfeContainer | null = null;
+  private static themeStyleRoot: MfeContainer = document;
   private static logger = FnLoggerService;
 
   mode: FNDashboardProps['mode'];
@@ -103,16 +103,10 @@ class createMfe {
   }
 
   private static setThemeStyleRoot(container: FNDashboardProps['container']) {
-    if (container) {
-      createMfe.themeStyleRoot = container;
-    }
+    createMfe.themeStyleRoot = container || document;
   }
 
   private static getThemeStyleRoot() {
-    if (!createMfe.themeStyleRoot) {
-      throw new Error('[FN Grafana]: Failed to load theme. MFE container does not exist.');
-    }
-
     return createMfe.themeStyleRoot;
   }
 

--- a/public/app/fn-app/create-mfe.ts
+++ b/public/app/fn-app/create-mfe.ts
@@ -4,6 +4,7 @@ declare let __webpack_public_path__: string;
 window.__grafana_public_path__ =
   __webpack_public_path__.substring(0, __webpack_public_path__.lastIndexOf('build/')) || __webpack_public_path__;
 
+import { cache as emotionCssCache } from '@emotion/css';
 import { isNull, merge, noop, pick } from 'lodash';
 import React, { ComponentType } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -118,6 +119,17 @@ class createMfe {
     return Array.from(styleRoot.querySelectorAll('link'));
   }
 
+  private static moveEmotionStylesToStyleRoot(styleRoot = createMfe.getThemeStyleRoot()) {
+    const styleTarget = createMfe.getThemeLinkTarget(styleRoot);
+
+    emotionCssCache.sheet.container = styleTarget;
+    emotionCssCache.sheet.tags.forEach((tag) => {
+      if (tag.parentNode !== styleTarget) {
+        styleTarget.appendChild(tag);
+      }
+    });
+  }
+
   private static createGrafanaTheme2(mode: FNDashboardProps['mode']) {
     config.theme2 = createTheme({
       colors: {
@@ -226,6 +238,7 @@ class createMfe {
       return new Promise((res, rej) => {
         try {
           createMfe.setThemeStyleRoot(props.container);
+          createMfe.moveEmotionStylesToStyleRoot();
           createMfe.loadFnTheme(props.mode);
           createMfe.Component = Component;
 
@@ -278,6 +291,7 @@ class createMfe {
       }
 
       backendSrv.cancelAllInFlightRequests();
+      createMfe.setThemeStyleRoot(null);
 
       return Promise.resolve(!!container);
     };
@@ -293,7 +307,8 @@ class createMfe {
     }: FNDashboardProps & {
       readonly renderingDashboardUid?: string;
     }) => {
-      createMfe.setThemeStyleRoot(container);
+      createMfe.setThemeStyleRoot(container ?? createMfe.getThemeStyleRoot());
+      createMfe.moveEmotionStylesToStyleRoot();
 
       if (mode && mfeGetStoreState().fnGlobalReducer.mode !== mode) {
         mfeDispatch(updateMfeMode(mode));

--- a/public/app/fn-app/create-mfe.ts
+++ b/public/app/fn-app/create-mfe.ts
@@ -28,7 +28,7 @@ import {
   updateMfeMode,
 } from 'app/store/configureMfeStore';
 
-import { FNDashboardProps, FailedToMountGrafanaErrorName } from './types';
+import { FNDashboardProps, FailedToMountGrafanaErrorName, MfeContainer } from './types';
 
 /**
  * NOTE:
@@ -59,6 +59,7 @@ type DeepPartial<T> = {
 
 class createMfe {
   private static readonly containerSelector = '#grafanaRoot';
+  private static themeStyleRoot: MfeContainer | null = null;
   private static logger = FnLoggerService;
 
   mode: FNDashboardProps['mode'];
@@ -101,6 +102,28 @@ class createMfe {
     return stylesheetLink;
   }
 
+  private static setThemeStyleRoot(container: FNDashboardProps['container']) {
+    if (container) {
+      createMfe.themeStyleRoot = container;
+    }
+  }
+
+  private static getThemeStyleRoot() {
+    if (!createMfe.themeStyleRoot) {
+      throw new Error('[FN Grafana]: Failed to load theme. MFE container does not exist.');
+    }
+
+    return createMfe.themeStyleRoot;
+  }
+
+  private static getThemeLinkTarget(styleRoot: MfeContainer) {
+    return styleRoot instanceof Document ? styleRoot.body : styleRoot;
+  }
+
+  private static getThemeLinks(styleRoot: MfeContainer) {
+    return Array.from(styleRoot.querySelectorAll('link'));
+  }
+
   private static createGrafanaTheme2(mode: FNDashboardProps['mode']) {
     config.theme2 = createTheme({
       colors: {
@@ -135,8 +158,12 @@ class createMfe {
   }
 
   // NOTE: based on grafana function: 'toggleTheme'
-  private static removeThemeLinks(modeToBeTurnedOff: GrafanaThemeType.Light | GrafanaThemeType.Dark, timeout?: number) {
-    Array.from(document.getElementsByTagName('link')).forEach(createMfe.removeThemeLink(modeToBeTurnedOff, timeout));
+  private static removeThemeLinks(
+    modeToBeTurnedOff: GrafanaThemeType.Light | GrafanaThemeType.Dark,
+    styleRoot: MfeContainer,
+    timeout?: number
+  ) {
+    createMfe.getThemeLinks(styleRoot).forEach(createMfe.removeThemeLink(modeToBeTurnedOff, timeout));
   }
 
   private static removeThemeLink(modeToBeTurnedOff: FNDashboardProps['mode'], timeout?: number) {
@@ -162,7 +189,11 @@ class createMfe {
    * NOTE:
    * If isRuntimeOnly then the stylesheets of the turned off theme are not removed
    */
-  private static loadFnTheme = (mode: FNDashboardProps['mode'] = GrafanaThemeType.Light, isRuntimeOnly = false) => {
+  private static loadFnTheme = (
+    mode: FNDashboardProps['mode'] = GrafanaThemeType.Light,
+    isRuntimeOnly = false,
+    styleRoot?: MfeContainer
+  ) => {
     createMfe.logger.info('Trying to load theme.', { mode });
 
     const grafanaTheme2 = createMfe.createGrafanaTheme2(mode);
@@ -179,11 +210,13 @@ class createMfe {
       return;
     }
 
-    createMfe.removeThemeLinks(createMfe.toggleTheme(mode));
+    const themeStyleRoot = styleRoot ?? createMfe.getThemeStyleRoot();
+
+    createMfe.removeThemeLinks(createMfe.toggleTheme(mode), themeStyleRoot);
 
     const newCssLink = createMfe.styleSheetLink;
     newCssLink.href = config.bootData.themePaths[mode];
-    document.body.appendChild(newCssLink);
+    createMfe.getThemeLinkTarget(themeStyleRoot).appendChild(newCssLink);
 
     createMfe.logger.info('Successfully loaded theme.', { mode });
   };
@@ -198,6 +231,7 @@ class createMfe {
     const lifeCycleFn: FrameworkLifeCycles['mount'] = (props: FNDashboardProps) => {
       return new Promise((res, rej) => {
         try {
+          createMfe.setThemeStyleRoot(props.container);
           createMfe.loadFnTheme(props.mode);
           createMfe.Component = Component;
 
@@ -260,10 +294,13 @@ class createMfe {
   static updateFnApp() {
     const lifeCycleFn: FrameworkLifeCycles['update'] = ({
       mode,
+      container,
       ...other
     }: FNDashboardProps & {
       readonly renderingDashboardUid?: string;
     }) => {
+      createMfe.setThemeStyleRoot(container);
+
       if (mode && mfeGetStoreState().fnGlobalReducer.mode !== mode) {
         mfeDispatch(updateMfeMode(mode));
 

--- a/public/app/fn-app/fn-app-provider.tsx
+++ b/public/app/fn-app/fn-app-provider.tsx
@@ -1,4 +1,7 @@
-import { useState, useEffect, FC, PropsWithChildren } from 'react';
+import createCache from '@emotion/cache';
+import { cache as emotionCssCache } from '@emotion/css';
+import { CacheProvider } from '@emotion/react';
+import { useState, useEffect, FC, PropsWithChildren, useMemo } from 'react';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { Store } from 'redux';
@@ -18,11 +21,32 @@ import app from '../fn_app';
 import { FNDashboardProps } from './types';
 
 type FnAppProviderProps = Pick<FNDashboardProps, 'fnError'> & {
+  container?: FNDashboardProps['container'];
   store: Store<StoreState>;
 };
 
 export const FnAppProvider: FC<PropsWithChildren<FnAppProviderProps>> = (props) => {
   const { children } = props;
+  const emotionCache = useMemo(
+    () => {
+      const container =
+        props.container instanceof Document ? props.container.head : props.container || document.head;
+
+      emotionCssCache.sheet.container = container;
+      emotionCssCache.sheet.tags.forEach((tag) => {
+        if (tag.parentNode !== container) {
+          container.appendChild(tag);
+        }
+      });
+
+      return createCache({
+        key: 'grafana-mf',
+        container,
+      });
+    },
+    [props.container]
+  );
+  const themeHref = config.bootData.themePaths[config.theme2.colors.mode];
 
   const [ready, setReady] = useState(false);
   navigationLogger('AppWrapper', false, 'rendering');
@@ -40,19 +64,22 @@ export const FnAppProvider: FC<PropsWithChildren<FnAppProviderProps>> = (props) 
   }
 
   return (
-    <Provider store={props.store}>
-      <BrowserRouter>
-        <ErrorBoundaryAlert style="page">
-          <GrafanaContext.Provider value={app.context}>
-            <ThemeProvider value={config.theme2}>
-              <div data-grafana-mf-root>
-                <GlobalStyles prefix="[data-grafana-mf-root]" />
-                {children}
-              </div>
-            </ThemeProvider>
-          </GrafanaContext.Provider>
-        </ErrorBoundaryAlert>
-      </BrowserRouter>
-    </Provider>
+    <CacheProvider value={emotionCache}>
+      <link rel="stylesheet" href={themeHref} />
+      <Provider store={props.store}>
+        <BrowserRouter>
+          <ErrorBoundaryAlert style="page">
+            <GrafanaContext.Provider value={app.context}>
+              <ThemeProvider value={config.theme2}>
+                <div data-grafana-mf-root>
+                  <GlobalStyles prefix="[data-grafana-mf-root]" />
+                  {children}
+                </div>
+              </ThemeProvider>
+            </GrafanaContext.Provider>
+          </ErrorBoundaryAlert>
+        </BrowserRouter>
+      </Provider>
+    </CacheProvider>
   );
 };

--- a/public/app/fn-app/fn-dashboard-page/fn-dashboard.tsx
+++ b/public/app/fn-app/fn-dashboard-page/fn-dashboard.tsx
@@ -71,18 +71,20 @@ export const DashboardPortal: FC<FNDashboardComponentProps> = (p) => {
 
       return (
         <RenderPortal ID={props.portalContainerID} key={uid}>
-          <FnAppProvider fnError={p.fnError} store={store}>
-            <div className="page-dashboard">
-              <RenderFNDashboard
-                {...{
-                  ...props,
-                  ...p,
-                  uid,
-                  mode: globalFnProps.mode,
-                }}
-              />
-            </div>
-          </FnAppProvider>
+          {(container) => (
+            <FnAppProvider container={container} fnError={p.fnError} store={store}>
+              <div className="page-dashboard">
+                <RenderFNDashboard
+                  {...{
+                    ...props,
+                    ...p,
+                    uid,
+                    mode: globalFnProps.mode,
+                  }}
+                />
+              </div>
+            </FnAppProvider>
+          )}
         </RenderPortal>
       );
     });

--- a/public/app/fn-app/types.ts
+++ b/public/app/fn-app/types.ts
@@ -16,11 +16,14 @@ export type GrafanaMicroFrontendActions = {
 export type AnyObject<K extends string | number | symbol = string, V = any> = {
   [key in K]: V;
 };
+
+export type MfeContainer = Document | DocumentFragment | HTMLElement;
+
 export interface FNDashboardProps extends FnState {
   name: string;
   fnError?: ReactNode;
   isLoading: (isLoading: boolean) => void;
   setErrors: (errors?: { [K: number | string]: string }) => void;
-  container?: HTMLElement | null;
+  container?: MfeContainer | null;
   mode: FnGlobalState['mode'];
 }

--- a/public/app/fn-app/utils.tsx
+++ b/public/app/fn-app/utils.tsx
@@ -1,16 +1,22 @@
-import { Portal } from '@mui/material';
-import { FC, PropsWithChildren } from 'react';
+import { FC, ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+import { MfeContainer } from './types';
 
 export interface RenderPortalProps {
   ID: string;
+  children: ReactNode | ((container: MfeContainer) => ReactNode);
 }
 
-export const RenderPortal: FC<PropsWithChildren<RenderPortalProps>> = ({ ID, children }) => {
+export const RenderPortal: FC<RenderPortalProps> = ({ ID, children }) => {
   const container = document.getElementById(ID);
 
   if (!container) {
     return null;
   }
 
-  return <Portal container={container}>{children}</Portal>;
+  const shadowRoot = container.shadowRoot || container.attachShadow({ mode: 'open' });
+  const content = typeof children === 'function' ? children(shadowRoot) : children;
+
+  return createPortal(content, shadowRoot);
 };

--- a/public/microfrontends/fn_dashboard/index.html
+++ b/public/microfrontends/fn_dashboard/index.html
@@ -1,6 +1,25 @@
-<!doctype html><html lang="en"><head><title>CodeRabbit Micro-frontend</title><base href="/"/></head><body class="theme-light app-grafana"><div id="grafanaRoot"></div><script nonce="">window.fnData = {
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>CodeRabbit Micro-frontend</title>
+    <base href="/" />
+  </head>
+
+  <body class="theme-light app-grafana">
+    <div id="grafanaRoot"></div>
+<script nonce="">
+  window.fnData = {
     themePaths: {
-      light: '../../../public/build/grafana.light.d120ca3c6b86113973bc.css',
-      dark: '../../../public/build/grafana.dark.f4571afb90da68f52521.css',
+      light: '../../../public/build/grafana.light.65904cef23d9f7f76c4a.css',
+      dark: '../../../public/build/grafana.dark.7c4d93ecbdd92098eb9a.css',
     }
-  };</script><script nonce="" src="../../../public/build/runtime.6bc90f2808f6a6cec604.js" integrity="../../../sha384-3As+cCSgxk8iweHxuF0ngRBgr9/ctzbHdj+SGyxLEsEcj6HkIQ9CSdeyXHvbZWHz" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6029.5c0893d1623856e7b325.js" integrity="../../../sha384-LCMBgpyynxT2jXlhS9LdLRKvKFwONDIYBW6yP4ZgNSZo7VxpgMGsUdspsX7oCvt5" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/5234.b70fab3b1fc48a116b38.js" integrity="../../../sha384-6z/x7G0Kuq5vHq8SixVqItA9g2cqD1Tw4nVd8f947akcoV/Y/8suL1cymdz83GDW" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/4159.2474818cd0a590b4b852.js" integrity="../../../sha384-mDVs9x2bqCV4KOdzAVdPIhNhftT6jp5rgT4z0W2PFICSgYO9WspVQ1NZEZ9uopBj" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/2410.606a87b065106e81ad31.js" integrity="../../../sha384-BFVRm68sCi1AfvPOncSziFN0wyR9pFWDILKADQNXW3osulVTaKUFvv6PVohbLlgE" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/9569.5956dfdd4b3fdd6a93a6.js" integrity="../../../sha384-Rt0UcbPtFvyQunoSipLsiTe0QFnqPd8+C9P4dKme0l0oWhfMRdjHufKTF4GjR4GN" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6263.c2ee3ac2fe2934607fe0.js" integrity="../../../sha384-2VdfTyu5FomdOEQn4OvRVDRX1C8TWJAVA9tPJlRoPq0FvWM+KhrzCtq6HNg2m9Fe" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6947.6fa9ff70b916365b6259.js" integrity="../../../sha384-IbuK21HpudeblOqkfNJfp6wvrHVlhxcd2s830P75awAlEiCS5pLngZ18qg0S0K/W" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/4894.89be4a92855ef9eb683b.js" integrity="../../../sha384-EoWaAzRvJN8kNdv/uj04uulL4FoocvQgg0+KIIlTi+FoNCAZHcxAj/pJ57FZi3qK" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/530.1c5ae442b33495c705a5.js" integrity="../../../sha384-Cv4HLe8qompnosQrBeW5214V6jyT5fWyYce0wl/H6F0e0VdI+icvpGcLUrnCqnHs" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/7223.d145fd99105c51a27905.js" integrity="../../../sha384-Ps7r+bS4dMRkHGzfn2hbwrLuPvsBrvH0BxwjA44TkTUo2u4JVwTRyvlT1EV+XtyH" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/280.04d501de6deac449c563.js" integrity="../../../sha384-ET/a2+qGxnfC4uCd8wYZrOjvnkYk7ZgeNwly0P/UoiogdLNhIftTGwFXRLqKEh5O" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/fn_dashboard.3b27ec7a6c915d13b983.js" integrity="../../../sha384-y5RXL2jFR/Tl6RXV1RQMqZI3kbEq6s8y6SZGjZvxKC9I2eQAbvbRrV20qIZlS8Mg" crossorigin="anonymous"></script></body></html>
+  };
+</script>
+
+     
+    <script nonce="" src="../../../public/build/runtime~fn_dashboard.a5d060ef4f8cb38ef003.js" type="text/javascript"></script>
+      
+    <script nonce="" src="../../../public/build/fn_dashboard.61924fc7a748b4f2ecc3.js" type="text/javascript"></script>
+     
+  </body>
+</html>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MFE can mount into Document, DocumentFragment, or HTMLElement containers.
  * Theme assets and runtime styles (Emotion) are scoped and injected into the chosen container.
  * Portals now render into a Shadow DOM container and can pass that container to children.

* **Refactor**
  * Mount/update/unmount lifecycle uses the provided container to load, move, and clean up theme and style assets.

* **Other**
  * Micro-frontend HTML updated to reference hashed theme CSS assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->