### PR TITLE
fix(fn-dashboard): do not mask empty panel query fields

### DIFF
--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -192,9 +192,9 @@ class LightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   };
 
   border = {
-    weak: '#e3e0e7',
-    medium: '#d0ccd5',
-    strong: '#bdb9c2',
+    weak: '#ebe9ee',
+    medium: '#dcd9e1',
+    strong: '#c4c0cb',
   };
 
   secondary = {
@@ -228,10 +228,12 @@ class LightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
     text: '#ab6400',
   };
 
+  // Panels sit on a pure-white surface floating over a soft mauve canvas so the
+  // card edges read cleanly, matching the Carrot UI light surfaces.
   background = {
-    primary: '#faf8fb',
-    canvas: '#e9e7ed',
-    secondary: '#fdfdfe',
+    primary: '#ffffff',
+    canvas: '#f5f3f7',
+    secondary: '#faf9fb',
   };
 
   action = {

--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -56,9 +56,11 @@ export interface ThemeComponents {
 }
 
 export function createComponents(colors: ThemeColors, shadows: ThemeShadows): ThemeComponents {
+  // Roomier panel chrome (12px gutters, 40px header) so charts breathe the way
+  // they do in the Carrot UI / Vercel card language instead of hugging the border.
   const panel = {
-    padding: 1,
-    headerHeight: 4,
+    padding: 1.5,
+    headerHeight: 5,
     background: colors.background.primary,
     borderColor: colors.border.weak,
     boxShadow: 'none',

--- a/packages/grafana-data/src/themes/createShadows.ts
+++ b/packages/grafana-data/src/themes/createShadows.ts
@@ -12,17 +12,19 @@ export function createShadows(colors: ThemeColors): ThemeShadows {
   // Shadow base colours are derived from the canvas background of each mode so
   // they harmonise with the mauve-tinted Carrot palette instead of using raw black.
   // Dark canvas #121014 → rgb(18, 16, 20)  |  Light text.primary #211f24 → rgb(33, 31, 36)
+  // Layered, low-opacity elevation in the Vercel/Geist style: a hairline contact
+  // shadow stacked with a wider ambient shadow instead of one heavy blur.
   if (colors.mode === 'dark') {
     return {
-      z1: '0px 1px 2px rgba(18, 16, 20, 0.8)',
-      z2: '0px 4px 8px rgba(18, 16, 20, 0.75)',
-      z3: '0px 8px 24px rgba(18, 16, 20, 0.9)',
+      z1: '0px 1px 2px rgba(0, 0, 0, 0.45)',
+      z2: '0px 2px 4px rgba(0, 0, 0, 0.35), 0px 8px 16px rgba(0, 0, 0, 0.4)',
+      z3: '0px 4px 8px rgba(0, 0, 0, 0.4), 0px 16px 32px rgba(0, 0, 0, 0.5)',
     };
   }
 
   return {
-    z1: '0px 1px 2px rgba(33, 31, 36, 0.12)',
-    z2: '0px 4px 8px rgba(33, 31, 36, 0.15)',
-    z3: '0px 13px 20px 1px rgba(33, 31, 36, 0.12)',
+    z1: '0px 1px 2px rgba(33, 31, 36, 0.06)',
+    z2: '0px 1px 2px rgba(33, 31, 36, 0.06), 0px 4px 12px rgba(33, 31, 36, 0.08)',
+    z3: '0px 2px 4px rgba(33, 31, 36, 0.06), 0px 12px 32px rgba(33, 31, 36, 0.12)',
   };
 }

--- a/packages/grafana-data/src/themes/createTypography.ts
+++ b/packages/grafana-data/src/themes/createTypography.ts
@@ -67,10 +67,12 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
     fontFamilyMonospace = defaultFontFamilyMonospace,
     // The default font size of the Material Specification.
     fontSize = 14, // px
-    fontWeightLight = 200,
-    fontWeightRegular = 300,
-    fontWeightMedium = 400,
-    fontWeightBold = 500,
+    // Geist/Vercel-style weight ramp. The previous 200/300/400/500 ramp rendered
+    // body copy as Light, which looked washed out against the Carrot UI palette.
+    fontWeightLight = 300,
+    fontWeightRegular = 400,
+    fontWeightMedium = 500,
+    fontWeightBold = 600,
     // Tell Grafana-UI what's the font-size on the html element.
     // 16px is the default font-size used by browsers.
     htmlFontSize = 16,
@@ -111,14 +113,16 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
 
   // All our fonts/line heights should be integer multiples of 2 to prevent issues with alignment
   const variants = {
-    h1: buildVariant(fontWeightRegular, 28, 32, -0.25),
-    h2: buildVariant(fontWeightRegular, 24, 28, 0),
-    h3: buildVariant(fontWeightRegular, 22, 24, 0),
-    h4: buildVariant(fontWeightRegular, 18, 22, 0.25),
-    h5: buildVariant(fontWeightRegular, 16, 22, 0),
-    h6: buildVariant(fontWeightMedium, 14, 22, 0.15),
-    body: buildVariant(fontWeightRegular, fontSize, 22, 0.15),
-    bodySmall: buildVariant(fontWeightRegular, 12, 18, 0.15),
+    // Headings use negative tracking (Vercel/Geist convention) and a heavier weight
+    // so panel titles and section headers read as deliberate UI chrome.
+    h1: buildVariant(fontWeightBold, 28, 32, -0.6),
+    h2: buildVariant(fontWeightBold, 24, 28, -0.5),
+    h3: buildVariant(fontWeightMedium, 22, 24, -0.4),
+    h4: buildVariant(fontWeightMedium, 18, 22, -0.3),
+    h5: buildVariant(fontWeightMedium, 16, 22, -0.2),
+    h6: buildVariant(fontWeightMedium, 14, 22, -0.1),
+    body: buildVariant(fontWeightRegular, fontSize, 22, 0),
+    bodySmall: buildVariant(fontWeightRegular, 12, 18, 0),
     code: { ...buildVariant(fontWeightRegular, 14, 16, 0.15), fontFamily: fontFamilyMonospace },
   };
 

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -55,6 +55,7 @@
     "@grafana/faro-web-sdk": "^1.3.6",
     "@grafana/schema": "11.3.0-pre",
     "@hello-pangea/dnd": "16.6.0",
+    "@heroicons/react": "2.2.0",
     "@leeoniya/ufuzzy": "1.0.14",
     "@monaco-editor/react": "4.6.0",
     "@popperjs/core": "2.11.8",

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerContent.tsx
@@ -162,7 +162,6 @@ const NarrowScreenForm = (props: FormProps) => {
               weekStart={weekStart}
             />
           </div>
-
         </div>
       )}
     </fieldset>
@@ -198,7 +197,6 @@ const FullScreenForm = (props: FormProps) => {
           weekStart={weekStart}
         />
       </div>
-
     </>
   );
 };
@@ -254,11 +252,16 @@ const useTimeOption = (raw: RawTimeRange, quickOptions: TimeOption[]): TimeOptio
 
 const getStyles = stylesFactory((theme: GrafanaTheme2, isReversed, hideQuickRanges, isContainerTall, isFullscreen) => {
   return {
+    // Carrot UI popover surface: soft 12px radius, hairline border and layered
+    // elevation so the panel floats above the dashboard rather than boxing it in.
+    // NOTE: no `overflow: hidden` here — the time zone / fiscal year selects render
+    // their menus inline (menuShouldPortal={false}), so clipping the container would
+    // crop the open dropdown list. Corner bleed is handled by the footer's own radius.
     container: css({
       background: theme.colors.background.primary,
       boxShadow: theme.shadows.z3,
       width: `${isFullscreen ? '546px' : '262px'}`,
-      borderRadius: theme.shape.borderRadius(),
+      borderRadius: theme.shape.borderRadius(3),
       border: `1px solid ${theme.colors.border.weak}`,
       [`${isReversed ? 'left' : 'right'}`]: 0,
     }),
@@ -286,7 +289,8 @@ const getStyles = stylesFactory((theme: GrafanaTheme2, isReversed, hideQuickRang
       flexDirection: 'column',
     }),
     timeRangeFilter: css({
-      padding: theme.spacing(1),
+      padding: theme.spacing(1.5),
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
     }),
     spacing: css({
       marginTop: '16px',
@@ -325,12 +329,11 @@ const getNarrowScreenStyles = (theme: GrafanaTheme2) => ({
 
 const getFullScreenStyles = (theme: GrafanaTheme2, hideQuickRanges?: boolean) => ({
   container: css({
-    paddingTop: '9px',
-    paddingLeft: '11px',
-    paddingRight: !hideQuickRanges ? '20%' : '11px',
+    padding: theme.spacing(1.5),
+    paddingRight: !hideQuickRanges ? '20%' : theme.spacing(1.5),
   }),
   title: css({
-    marginBottom: '11px',
+    marginBottom: theme.spacing(1.5),
   }),
   recent: css({
     flexGrow: 1,

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerFooter.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerFooter.tsx
@@ -169,26 +169,39 @@ export const TimePickerFooter = (props: Props) => {
 
 const getStyle = stylesFactory((theme: GrafanaTheme2) => {
   return {
+    // Footer reads as a distinct utility bar: recessed surface, hairline top rule.
+    // `:last-child` keeps the rounding on whichever block actually ends the popover
+    // (this bar when collapsed, the edit panel when the settings are expanded).
     container: css({
       borderTop: `1px solid ${theme.colors.border.weak}`,
-      padding: '11px',
+      background: theme.colors.background.secondary,
+      padding: theme.spacing(1.5),
       display: 'flex',
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      fontSize: '14px',
+      fontSize: theme.typography.bodySmall.fontSize,
       lineHeight: '20px',
+      '&:last-child': {
+        borderBottomLeftRadius: theme.shape.borderRadius(3),
+        borderBottomRightRadius: theme.shape.borderRadius(3),
+      },
       '& button': {
-        borderRadius: '6px',
+        borderRadius: theme.shape.radius.default,
       },
     }),
     editContainer: css({
       borderTop: `1px solid ${theme.colors.border.weak}`,
-      padding: '11px',
+      background: theme.colors.background.secondary,
+      padding: theme.spacing(1.5),
       justifyContent: 'space-between',
       alignItems: 'center',
-      fontSize: '14px',
+      fontSize: theme.typography.bodySmall.fontSize,
       lineHeight: '20px',
+      // Round the trailing corners to match the popover instead of relying on the
+      // parent clipping, which would crop the inline select menus.
+      borderBottomLeftRadius: theme.shape.borderRadius(3),
+      borderBottomRightRadius: theme.shape.borderRadius(3),
     }),
     spacer: css({
       marginLeft: '7px',
@@ -216,9 +229,22 @@ const getStyle = stylesFactory((theme: GrafanaTheme2) => {
     // orange brand gradient) with a neutral gray for the time-zone /
     // fiscal-year tabs inside the time-range picker only.
     tabsOverride: css({
-      'button[role="tab"][aria-selected="true"]::before, a[role="tab"][aria-selected="true"]::before': {
+      '[role="tab"][aria-selected="true"]': {
+        // The shared Tab sets `overflow: hidden` on the active state, which clips
+        // its own rounded underline into a boxed outline around the tab. Reset it
+        // so only the underline shows.
+        overflow: 'visible',
+        border: 'none',
+        boxShadow: 'none',
+      },
+
+      '[role="tab"][aria-selected="true"]::before': {
         backgroundImage: 'none',
-        backgroundColor: theme.colors.border.strong,
+        backgroundColor: theme.colors.text.primary,
+        // A slim square-cut rule reads as an underline; the inherited 4px/6px-radius
+        // bar looked like a stray border sitting under the label.
+        height: '2px',
+        borderRadius: 0,
       },
     }),
   };

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerTitle.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerTitle.tsx
@@ -7,10 +7,14 @@ import { useStyles2 } from '../../../themes';
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
+    // Section labels read as small-caps eyebrows (Carrot UI convention) so the
+    // quick-range values below them stay the dominant text in the popover.
     text: css({
-      fontSize: theme.typography.size.md,
+      fontSize: theme.typography.size.xs,
       fontWeight: theme.typography.fontWeightMedium,
-      color: theme.colors.text.primary,
+      textTransform: 'uppercase',
+      letterSpacing: '0.06em',
+      color: theme.colors.text.secondary,
       margin: 0,
       display: 'flex',
     }),

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeList.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeList.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useRef, ReactNode } from 'react';
 
-import { TimeOption } from '@grafana/data';
+import { GrafanaTheme2, TimeOption } from '@grafana/data';
 
 import { useStyles2 } from '../../../themes';
 import { t } from '../../../utils/i18n';
@@ -82,12 +82,12 @@ function isEqual(x: TimeOption, y?: TimeOption): boolean {
   return y.from === x.from && y.to === x.to;
 }
 
-const getStyles = () => ({
+const getStyles = (theme: GrafanaTheme2) => ({
   title: css({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    padding: '8px 16px 5px 9px',
+    padding: theme.spacing(1.5, 2, 0.75, 2),
   }),
 });
 

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeOption.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeOption.tsx
@@ -9,16 +9,23 @@ import { getFocusStyles } from '../../../themes/mixins';
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
+    // Carrot UI list rows: inset pills with a rounded hover/selected surface
+    // instead of full-bleed bars butting against the popover edges.
     container: css({
       display: 'flex',
       alignItems: 'center',
       flexDirection: 'row-reverse',
       justifyContent: 'space-between',
+      padding: theme.spacing(0, 1),
     }),
+    // Selected uses the neutral secondary surface rather than the brand orange:
+    // an orange fill fights the panel accents and hurts label contrast.
     selected: css({
-      background: theme.colors.secondary.main,
-      color: theme.colors.secondary.text,
-      fontWeight: theme.typography.fontWeightMedium,
+      '& label, & label:hover': {
+        background: theme.colors.secondary.main,
+        color: theme.colors.text.primary,
+        fontWeight: theme.typography.fontWeightMedium,
+      },
     }),
     radio: css({
       opacity: 0,
@@ -30,11 +37,17 @@ const getStyles = (theme: GrafanaTheme2) => {
       cursor: 'pointer',
       flex: 1,
       padding: theme.spacing(0.75, 1.25),
-      fontSize: '14px',
+      borderRadius: theme.shape.radius.default,
+      fontSize: theme.typography.bodySmall.fontSize,
       lineHeight: '20px',
+      color: theme.colors.text.secondary,
+      transition: theme.transitions.create(['background-color', 'color'], {
+        duration: theme.transitions.duration.shortest,
+      }),
 
       '&:hover': {
         background: theme.colors.action.hover,
+        color: theme.colors.text.primary,
         cursor: 'pointer',
       },
     }),

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -295,7 +295,11 @@ export function PanelChrome({
       )}
 
       {hasHeader && (
-        <div className={cx(styles.headerContainer, dragClass)} style={headerStyles} data-testid="header-container">
+        <div
+          className={cx(styles.headerContainer, title && styles.headerDivider, dragClass)}
+          style={headerStyles}
+          data-testid="header-container"
+        >
           {statusMessage && (
             <div className={dragClassCancel}>
               <PanelStatus message={statusMessage} onClick={statusMessageOnClick} ariaLabel="Panel status" />
@@ -387,12 +391,16 @@ const getStyles = (isFNPanel?: boolean) => (theme: GrafanaTheme2) => {
       label: 'panel-container',
       backgroundColor: background,
       border: `1px solid ${borderColor}`,
-      borderRadius: theme.shape.borderRadius(2),
+      // Larger corner radius + soft elevation to match the Carrot UI card language.
+      borderRadius: theme.shape.borderRadius(3),
       boxShadow: theme.shadows.z1,
       position: 'relative',
       height: '100%',
       display: 'flex',
       flexDirection: 'column',
+      transition: theme.transitions.create(['box-shadow', 'border-color'], {
+        duration: theme.transitions.duration.short,
+      }),
 
       '.show-on-hover': {
         opacity: '0',
@@ -400,6 +408,7 @@ const getStyles = (isFNPanel?: boolean) => (theme: GrafanaTheme2) => {
       },
 
       '&:hover': {
+        borderColor: theme.colors.border.medium,
         boxShadow: theme.shadows.z2,
         // only show menu icon on hover
         '.show-on-hover': {
@@ -461,6 +470,13 @@ const getStyles = (isFNPanel?: boolean) => (theme: GrafanaTheme2) => {
       display: 'flex',
       alignItems: 'center',
     }),
+    // Hairline separator between the title row and the visualisation, the way
+    // Vercel-style cards split header from body. Only applied when the panel
+    // actually renders a title, so untitled panels stay borderless.
+    headerDivider: css({
+      label: 'panel-header-divider',
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+    }),
     pointer: css({
       cursor: 'pointer',
     }),
@@ -476,8 +492,15 @@ const getStyles = (isFNPanel?: boolean) => (theme: GrafanaTheme2) => {
     title: css({
       label: 'panel-title',
       display: 'flex',
+      alignItems: 'center',
       padding: theme.spacing(0, padding),
       minWidth: 0,
+      // Panel titles are secondary chrome: slightly muted, tighter tracking.
+      '& h2': {
+        color: theme.colors.text.primary,
+        fontWeight: theme.typography.fontWeightMedium,
+        letterSpacing: '-0.01em',
+      },
       // FN-dashboard panel titles span the full chrome width so the title
       // and the right-aligned menu line up edge-to-edge. Titles render in
       // normal case — the uppercase transform that previously lived here

--- a/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
@@ -1,9 +1,9 @@
 import { css, cx } from '@emotion/css';
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes';
-import { Icon } from '../Icon/Icon';
 import { Tooltip } from '../Tooltip';
 
 import { TitleItem } from './TitleItem';
@@ -30,7 +30,8 @@ export function PanelDescription({ description, className }: Props) {
   return description !== '' ? (
     <Tooltip interactive content={getDescriptionContent}>
       <TitleItem className={cx(className, styles.description)}>
-        <Icon name="info-circle" size="md" />
+        {/* Heroicons is the icon set used by the CodeRabbit UI (Carrot UI) design system. */}
+        <InformationCircleIcon className={styles.icon} aria-hidden />
       </TitleItem>
     </Tooltip>
   ) : null;
@@ -46,6 +47,19 @@ const getStyles = (theme: GrafanaTheme2) => {
 
       'pre > code': {
         display: 'block',
+      },
+    }),
+    icon: css({
+      width: 16,
+      height: 16,
+      flexShrink: 0,
+      color: theme.colors.text.secondary,
+      transition: theme.transitions.create('color', {
+        duration: theme.transitions.duration.shortest,
+      }),
+
+      '&:hover': {
+        color: theme.colors.text.primary,
       },
     }),
   };

--- a/packages/grafana-ui/src/components/PanelChrome/TitleItem.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/TitleItem.tsx
@@ -39,7 +39,15 @@ export const TitleItem = forwardRef<TitleItemElement, TitleItemProps>(
       );
     } else if (onClick) {
       return (
-        <Button ref={ref} className={cx(styles.item, className)} variant="secondary" fill="text" onClick={onClick}>
+        <Button
+          ref={ref}
+          className={cx(styles.item, className)}
+          variant="secondary"
+          fill="text"
+          onClick={onClick}
+          title={title}
+          {...rest}
+        >
           {children}
         </Button>
       );

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -175,6 +175,7 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 		FolderTitle:            "General",
 		AnnotationsPermissions: annotationPermissions,
 		PublicDashboardEnabled: publicDashboardEnabled,
+		WorkspaceID:            dash.WorkspaceID,
 	}
 	metrics.MFolderIDsAPICount.WithLabelValues(metrics.GetDashboard).Inc()
 	// lookup folder title

--- a/pkg/api/dashboard_mfe_mask.go
+++ b/pkg/api/dashboard_mfe_mask.go
@@ -190,7 +190,25 @@ func maskTemplatingList(list *simplejson.Json) {
 func maskRawQueryFields(obj *simplejson.Json, mask string) {
 	for _, field := range mfeMaskedQueryFields {
 		if cur, ok := obj.CheckGet(field); ok {
-			if _, err := cur.String(); err == nil {
+			if s, err := cur.String(); err == nil {
+				// An empty query field has nothing to hide, and masking it is
+				// actively harmful: it fabricates a `[MFE_REDACTED:p:<id>:<refId>]`
+				// marker that promises the proxy a query which does not exist. The
+				// proxy then looks the panel up, finds an empty `rawSql`, and fails
+				// the whole batch closed rather than rendering the panel.
+				//
+				// Two shapes rely on an intentionally empty query field:
+				//   - CodeRabbit reporting-backed panels, whose data comes from the
+				//     reporting API via a `crReportingTag` on the target rather than
+				//     from SQL.
+				//   - Variable metricFindQueries, which the frontend already sends
+				//     with an empty rawSql and a `tempVar<N>` refId.
+				//
+				// Leaving the empty string untouched is safe by construction: there
+				// is no query text to leak.
+				if strings.TrimSpace(s) == "" {
+					continue
+				}
 				obj.Set(field, mask)
 			}
 		}

--- a/pkg/api/dashboard_mfe_mask_test.go
+++ b/pkg/api/dashboard_mfe_mask_test.go
@@ -260,6 +260,72 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 // The proxy decodes each segment with `decodeURIComponent`, which preserves
 // `+` literally — so emitting `+` for space here would break the round-trip
 // for refIDs / variable names containing spaces.
+func TestMaskDashboardQueriesLeavesEmptyQueryFields(t *testing.T) {
+	// Regression: masking an empty rawSql fabricated a redaction marker that
+	// promised the CodeRabbit proxy a query which does not exist. The proxy
+	// resolved the panel, found no SQL, and failed the whole /api/ds/query batch
+	// with "Failed to resolve FN-redacted query".
+	t.Run("leaves an empty rawSql untouched", func(t *testing.T) {
+		raw := []byte(`{
+			"panels": [
+				{
+					"id": 4,
+					"targets": [
+						{
+							"refId": "A",
+							"rawSql": "",
+							"crReportingTag": "[CR_REPORT:abc]"
+						}
+					]
+				}
+			]
+		}`)
+		data, err := simplejson.NewJson(raw)
+		require.NoError(t, err)
+
+		maskDashboardQueriesForMFE(data)
+
+		target := data.Get("panels").GetIndex(0).Get("targets").GetIndex(0)
+		require.Equal(t, "", target.Get("rawSql").MustString())
+		// The reporting tag is not a masked query field and must survive intact.
+		require.Equal(t, "[CR_REPORT:abc]", target.Get("crReportingTag").MustString())
+	})
+
+	t.Run("leaves a whitespace-only query untouched", func(t *testing.T) {
+		raw := []byte(`{
+			"panels": [
+				{"id": 7, "targets": [{"refId": "A", "rawSql": "   "}]}
+			]
+		}`)
+		data, err := simplejson.NewJson(raw)
+		require.NoError(t, err)
+
+		maskDashboardQueriesForMFE(data)
+
+		target := data.Get("panels").GetIndex(0).Get("targets").GetIndex(0)
+		require.Equal(t, "   ", target.Get("rawSql").MustString())
+	})
+
+	t.Run("still masks a non-empty query on the same dashboard", func(t *testing.T) {
+		raw := []byte(`{
+			"panels": [
+				{"id": 4, "targets": [{"refId": "A", "rawSql": ""}]},
+				{"id": 5, "targets": [{"refId": "A", "rawSql": "SELECT 1"}]}
+			]
+		}`)
+		data, err := simplejson.NewJson(raw)
+		require.NoError(t, err)
+
+		maskDashboardQueriesForMFE(data)
+
+		panels := data.Get("panels")
+		require.Equal(t, "", panels.GetIndex(0).Get("targets").GetIndex(0).Get("rawSql").MustString())
+		require.Equal(t,
+			"[MFE_REDACTED:p:5:A]",
+			panels.GetIndex(1).Get("targets").GetIndex(0).Get("rawSql").MustString())
+	})
+}
+
 func TestMfeEncodeMaskSegment(t *testing.T) {
 	cases := map[string]string{
 		"":             "",

--- a/pkg/api/dtos/dashboard.go
+++ b/pkg/api/dtos/dashboard.go
@@ -36,6 +36,9 @@ type DashboardMeta struct {
 	AnnotationsPermissions *dashboardsV0.AnnotationPermission `json:"annotationsPermissions"`
 	PublicDashboardEnabled bool                               `json:"publicDashboardEnabled,omitempty"`
 	HasPublicDashboard     bool                               `json:"hasPublicDashboard,omitempty"`
+	// WorkspaceID scopes a dashboard to a CodeRabbit workspace. Empty for
+	// dashboards provisioned outside the micro frontend flow.
+	WorkspaceID string `json:"workspaceId,omitempty"`
 }
 
 type DashboardFullWithMeta struct {

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -96,6 +96,9 @@ func (hs *HTTPServer) Search(c *contextmodel.ReqContext) response.Response {
 		FolderUIDs:    folderUIDs,
 		Permission:    permission,
 		Sort:          sort,
+		// CodeRabbit MFE: scopes AI-generated custom dashboards to the calling
+		// product workspace. Ignored when absent.
+		WorkspaceID: c.Query("workspaceId"),
 	}
 
 	hits, err := hs.SearchService.SearchHandler(c.Req.Context(), &searchQuery)

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -850,6 +850,10 @@ func (d *dashboardStore) FindDashboards(ctx context.Context, query *dashboards.F
 		filters = append(filters, searchstore.TagsFilter{Tags: query.Tags})
 	}
 
+	if query.WorkspaceID != "" {
+		filters = append(filters, searchstore.WorkspaceFilter{WorkspaceID: query.WorkspaceID})
+	}
+
 	if len(query.DashboardUIDs) > 0 {
 		filters = append(filters, searchstore.DashboardFilter{UIDs: query.DashboardUIDs})
 	} else if len(query.DashboardIds) > 0 {

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -48,6 +48,11 @@ type Dashboard struct {
 
 	Title string
 	Data  *simplejson.Json
+
+	// WorkspaceID is the CodeRabbit product workspace that owns this dashboard.
+	// Only set for AI-generated custom dashboards saved through the MFE; empty
+	// for every dashboard provisioned the normal Grafana way.
+	WorkspaceID string `xorm:"workspace_id"`
 }
 
 func (d *Dashboard) SetID(id int64) {
@@ -136,6 +141,7 @@ func (cmd *SaveDashboardCommand) GetDashboardModel() *Dashboard {
 
 	dash.UpdatedBy = userID
 	dash.OrgID = cmd.OrgID
+	dash.WorkspaceID = cmd.WorkspaceID
 	dash.PluginID = cmd.PluginID
 	dash.IsFolder = cmd.IsFolder
 	metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Dashboard).Inc()
@@ -206,6 +212,11 @@ type SaveDashboardCommand struct {
 	FolderID  int64  `json:"folderId" xorm:"folder_id"`
 	FolderUID string `json:"folderUid" xorm:"folder_uid"`
 	IsFolder  bool   `json:"isFolder"`
+
+	// WorkspaceID scopes an AI-generated custom dashboard to a CodeRabbit
+	// product workspace. Accepted from the save payload so the handler can
+	// persist it without a second write.
+	WorkspaceID string `json:"workspaceId" xorm:"workspace_id"`
 
 	UpdatedAt time.Time
 }
@@ -416,11 +427,15 @@ type FindPersistedDashboardsQuery struct {
 	FolderIds  []int64
 	FolderUIDs []string
 	Tags       []string
-	Limit      int64
-	Page       int64
-	Permission dashboardaccess.PermissionType
-	Sort       model.SortOption
-	IsDeleted  bool
+	// WorkspaceID restricts results to dashboards owned by a single CodeRabbit
+	// product workspace. Empty means "no workspace filter" and preserves the
+	// stock Grafana search behaviour.
+	WorkspaceID string
+	Limit       int64
+	Page        int64
+	Permission  dashboardaccess.PermissionType
+	Sort        model.SortOption
+	IsDeleted   bool
 
 	Filters []any
 }

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -217,15 +217,16 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 
 	metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Dashboard).Inc()
 	cmd := &dashboards.SaveDashboardCommand{
-		Dashboard: dash.Data,
-		Message:   dto.Message,
-		OrgID:     dto.OrgID,
-		Overwrite: dto.Overwrite,
-		UserID:    userID,
-		FolderID:  dash.FolderID, // nolint:staticcheck
-		FolderUID: dash.FolderUID,
-		IsFolder:  dash.IsFolder,
-		PluginID:  dash.PluginID,
+		Dashboard:   dash.Data,
+		Message:     dto.Message,
+		OrgID:       dto.OrgID,
+		Overwrite:   dto.Overwrite,
+		UserID:      userID,
+		FolderID:    dash.FolderID, // nolint:staticcheck
+		FolderUID:   dash.FolderUID,
+		IsFolder:    dash.IsFolder,
+		PluginID:    dash.PluginID,
+		WorkspaceID: dash.WorkspaceID,
 	}
 
 	if !dto.UpdatedAt.IsZero() {

--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -48,6 +48,8 @@ type Query struct {
 	FolderUIDs []string
 	Permission dashboardaccess.PermissionType
 	Sort       string
+	// WorkspaceID scopes results to a single CodeRabbit product workspace.
+	WorkspaceID string
 }
 
 type Service interface {
@@ -101,6 +103,7 @@ func (s *SearchService) SearchHandler(ctx context.Context, query *Query) (model.
 		Page:          query.Page,
 		Permission:    query.Permission,
 		IsDeleted:     query.IsDeleted,
+		WorkspaceID:   query.WorkspaceID,
 	}
 
 	if sortOpt, exists := s.sortOptions[query.Sort]; exists {

--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -239,6 +239,19 @@ func addDashboardMigration(mg *Migrator) {
 		Name: "deleted", Type: DB_DateTime, Nullable: true,
 	}))
 
+	// CodeRabbit MFE: AI-generated custom dashboards are provisioned per
+	// product workspace rather than per Grafana org, so the owning workspace is
+	// stored alongside the dashboard and used to scope list/read access.
+	// Nullable so every pre-existing dashboard row stays valid.
+	mg.AddMigration("Add workspace_id for dashboard", NewAddColumnMigration(dashboardV2, &Column{
+		Name: "workspace_id", Type: DB_NVarchar, Length: 190, Nullable: true,
+	}))
+
+	mg.AddMigration("Add index for dashboard workspace_id", NewAddIndexMigration(dashboardV2, &Index{
+		Cols: []string{"workspace_id"},
+		Type: IndexType,
+	}))
+
 	mg.AddMigration("Add index for deleted", NewAddIndexMigration(dashboardV2, &Index{
 		Cols: []string{"deleted"},
 		Type: IndexType,

--- a/pkg/services/sqlstore/searchstore/filters.go
+++ b/pkg/services/sqlstore/searchstore/filters.go
@@ -219,3 +219,16 @@ func (f DeletedFilter) Where() (string, []any) {
 
 	return "dashboard.deleted IS NULL", nil
 }
+
+// WorkspaceFilter restricts results to dashboards owned by a single CodeRabbit
+// product workspace. Applied only when a workspace id is supplied, so stock
+// Grafana search behaviour is unchanged for every other caller.
+type WorkspaceFilter struct {
+	WorkspaceID string
+}
+
+var _ model.FilterWhere = WorkspaceFilter{}
+
+func (f WorkspaceFilter) Where() (string, []any) {
+	return "dashboard.workspace_id = ?", []any{f.WorkspaceID}
+}

--- a/pkg/services/sqlstore/searchstore/filters_test.go
+++ b/pkg/services/sqlstore/searchstore/filters_test.go
@@ -57,3 +57,12 @@ func TestFolderUIDFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkspaceFilter(t *testing.T) {
+	f := searchstore.WorkspaceFilter{WorkspaceID: "ws-123"}
+
+	sql, params := f.Where()
+
+	assert.Equal(t, "dashboard.workspace_id = ?", sql)
+	assert.Equal(t, []any{"ws-123"}, params)
+}

--- a/public/app/core/reducers/fn-slice.test.ts
+++ b/public/app/core/reducers/fn-slice.test.ts
@@ -1,0 +1,7 @@
+import { fnStateProps } from './fn-slice';
+
+describe('fn-slice', () => {
+  it('includes the host portal container id in copied microfrontend state props', () => {
+    expect(fnStateProps).toContain('portalContainerID');
+  });
+});

--- a/public/app/core/reducers/fn-slice.ts
+++ b/public/app/core/reducers/fn-slice.ts
@@ -9,6 +9,7 @@ export interface FnState {
   slug: string;
   version: number;
   controlsContainer: string | null;
+  dashboardAccessMode: 'standard' | 'custom';
   pageTitle: string;
   queryParams: AnyObject;
   hiddenVariables: string[];
@@ -18,6 +19,7 @@ export interface FnState {
    * owns the editing UI, so Grafana only surfaces the trigger.
    */
   enablePanelEdit: boolean;
+  enablePanelLayoutEdit: boolean;
   metadata: {
     teams: string[];
     eventListener: (<T>(event: { type: string; data: T }) => void) | null;
@@ -39,7 +41,10 @@ export type FnPropMappedFromState = Extract<
   | 'slug'
   | 'version'
   | 'controlsContainer'
+  | 'dashboardAccessMode'
   | 'enablePanelEdit'
+  | 'enablePanelLayoutEdit'
+  | 'portalContainerID'
 >;
 export type FnStateProp = keyof FnState;
 
@@ -47,9 +52,12 @@ export type FnPropsMappedFromState = Pick<FnGlobalState, FnPropMappedFromState>;
 
 export const fnStateProps: FnStateProp[] = [
   'controlsContainer',
+  'dashboardAccessMode',
   'enablePanelEdit',
+  'enablePanelLayoutEdit',
   'hiddenVariables',
   'pageTitle',
+  'portalContainerID',
   'queryParams',
   'slug',
   'uid',
@@ -66,10 +74,12 @@ export const INITIAL_FN_STATE: FnState = {
   slug: '',
   version: 1,
   controlsContainer: null,
+  dashboardAccessMode: 'standard',
   pageTitle: '',
   queryParams: {},
   hiddenVariables: [],
   enablePanelEdit: false,
+  enablePanelLayoutEdit: false,
   metadata: {
     teams: [],
     eventListener: null,

--- a/public/app/core/reducers/fn-slice.ts
+++ b/public/app/core/reducers/fn-slice.ts
@@ -12,6 +12,12 @@ export interface FnState {
   pageTitle: string;
   queryParams: AnyObject;
   hiddenVariables: string[];
+  /**
+   * When true, each panel header renders an edit affordance that reports the
+   * clicked panel back to the host through `metadata.eventListener`. The host
+   * owns the editing UI, so Grafana only surfaces the trigger.
+   */
+  enablePanelEdit: boolean;
   metadata: {
     teams: string[];
     eventListener: (<T>(event: { type: string; data: T }) => void) | null;
@@ -25,7 +31,15 @@ export type SetFnStateAction = PayloadAction<Omit<FnGlobalState, 'hiddenVariable
 
 export type FnPropMappedFromState = Extract<
   keyof FnGlobalState,
-  'FNDashboard' | 'hiddenVariables' | 'mode' | 'uid' | 'queryParams' | 'slug' | 'version' | 'controlsContainer'
+  | 'FNDashboard'
+  | 'hiddenVariables'
+  | 'mode'
+  | 'uid'
+  | 'queryParams'
+  | 'slug'
+  | 'version'
+  | 'controlsContainer'
+  | 'enablePanelEdit'
 >;
 export type FnStateProp = keyof FnState;
 
@@ -33,6 +47,7 @@ export type FnPropsMappedFromState = Pick<FnGlobalState, FnPropMappedFromState>;
 
 export const fnStateProps: FnStateProp[] = [
   'controlsContainer',
+  'enablePanelEdit',
   'hiddenVariables',
   'pageTitle',
   'queryParams',
@@ -54,6 +69,7 @@ export const INITIAL_FN_STATE: FnState = {
   pageTitle: '',
   queryParams: {},
   hiddenVariables: [],
+  enablePanelEdit: false,
   metadata: {
     teams: [],
     eventListener: null,

--- a/public/app/core/reducers/fn-slice.ts
+++ b/public/app/core/reducers/fn-slice.ts
@@ -5,9 +5,9 @@ import { GrafanaThemeType } from '@grafana/data';
 import { AnyObject } from '../../fn-app/types';
 
 export interface FnPanelOptionsUpdate {
-  options: Record<string, unknown>;
-  panelId: number;
-  revision: number;
+  readonly options: Readonly<Record<string, unknown>>;
+  readonly panelId: number;
+  readonly revision: number;
 }
 
 export interface FnState {

--- a/public/app/core/reducers/fn-slice.ts
+++ b/public/app/core/reducers/fn-slice.ts
@@ -4,6 +4,12 @@ import { GrafanaThemeType } from '@grafana/data';
 
 import { AnyObject } from '../../fn-app/types';
 
+export interface FnPanelOptionsUpdate {
+  options: Record<string, unknown>;
+  panelId: number;
+  revision: number;
+}
+
 export interface FnState {
   uid: string;
   slug: string;
@@ -24,6 +30,7 @@ export interface FnState {
     teams: string[];
     eventListener: (<T>(event: { type: string; data: T }) => void) | null;
   };
+  panelOptionsUpdate?: FnPanelOptionsUpdate;
   portalContainerID: string;
 }
 
@@ -44,6 +51,7 @@ export type FnPropMappedFromState = Extract<
   | 'dashboardAccessMode'
   | 'enablePanelEdit'
   | 'enablePanelLayoutEdit'
+  | 'panelOptionsUpdate'
   | 'portalContainerID'
 >;
 export type FnStateProp = keyof FnState;
@@ -57,6 +65,7 @@ export const fnStateProps: FnStateProp[] = [
   'enablePanelLayoutEdit',
   'hiddenVariables',
   'pageTitle',
+  'panelOptionsUpdate',
   'portalContainerID',
   'queryParams',
   'slug',
@@ -84,6 +93,7 @@ export const INITIAL_FN_STATE: FnState = {
     teams: [],
     eventListener: null,
   },
+  panelOptionsUpdate: undefined,
   portalContainerID: 'grafana-portal',
 } as const;
 

--- a/public/app/features/dashboard/containers/DashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.test.tsx
@@ -1,0 +1,201 @@
+import type { FieldConfigSource } from '@grafana/data';
+import type { PanelModel } from 'app/features/dashboard/state';
+
+import { applyFnPanelOptionsPreview } from './DashboardPageFnPanelOptions';
+
+interface PanelStub {
+  description?: string;
+  fieldConfig: FieldConfigSource;
+  id: number;
+  options: Record<string, unknown>;
+  render: jest.Mock<void, []>;
+  title: string;
+  type: string;
+  updateFieldConfig: jest.Mock<void, [FieldConfigSource]>;
+  updateOptions: jest.Mock<void, [Record<string, unknown>]>;
+}
+
+function getPanel(
+  type: string,
+  panelOverrides: Partial<Pick<PanelStub, 'description' | 'fieldConfig' | 'options' | 'title'>> = {}
+): PanelModel & PanelStub {
+  const panel: PanelStub = {
+    fieldConfig: { defaults: {}, overrides: [] },
+    id: 1,
+    options: {},
+    render: jest.fn<void, []>(),
+    title: 'Panel',
+    type,
+    updateFieldConfig: jest.fn<void, [FieldConfigSource]>(),
+    updateOptions: jest.fn<void, [Record<string, unknown>]>(),
+    ...panelOverrides,
+  };
+
+  panel.updateFieldConfig.mockImplementation((fieldConfig) => {
+    panel.fieldConfig = fieldConfig;
+  });
+  panel.updateOptions.mockImplementation((options) => {
+    panel.options = options;
+  });
+
+  return panel as PanelModel & PanelStub;
+}
+
+function applyOptions(panel: PanelModel, options: Record<string, unknown>): void {
+  applyFnPanelOptionsPreview(panel, {
+    options,
+    panelId: panel.id,
+    revision: 1,
+  });
+}
+
+describe('applyFnPanelOptionsPreview', () => {
+  it('applies common field config and stat text options', () => {
+    const panel = getPanel('stat', {
+      options: { text: { valueSize: 18 } },
+    });
+
+    applyOptions(panel, {
+      decimals: 2,
+      description: 'Updated description',
+      fontSize: 36,
+      title: 'Updated title',
+      unit: 'suffix:s',
+    });
+
+    expect(panel.title).toBe('Updated title');
+    expect(panel.description).toBe('Updated description');
+    expect(panel.fieldConfig.defaults).toEqual(
+      expect.objectContaining({
+        decimals: 2,
+        unit: 'suffix:s',
+      })
+    );
+    expect(panel.options).toEqual(expect.objectContaining({ text: { valueSize: 36 } }));
+  });
+
+  it('applies table pagination, filters, sort, header, and footer options', () => {
+    const panel = getPanel('table');
+
+    applyOptions(panel, {
+      tableCellHeight: 'lg',
+      tableColumnFilter: true,
+      tableFooter: true,
+      tablePagination: true,
+      tableShowHeader: false,
+      tableSortBy: 'Author',
+      tableSortDesc: true,
+    });
+
+    expect(panel.fieldConfig.defaults.custom).toEqual({ filterable: true });
+    expect(panel.options).toEqual(
+      expect.objectContaining({
+        cellHeight: 'lg',
+        footer: expect.objectContaining({
+          enablePagination: true,
+          show: true,
+        }),
+        showHeader: false,
+        sortBy: [{ desc: true, displayName: 'Author' }],
+      })
+    );
+  });
+
+  it('applies timeseries style, stacking, legend, and tooltip options', () => {
+    const panel = getPanel('timeseries', {
+      fieldConfig: {
+        defaults: { custom: { stacking: { group: 'B', mode: 'none' } } },
+        overrides: [],
+      },
+      options: { legend: { displayMode: 'list', placement: 'bottom', showLegend: true } },
+    });
+
+    applyOptions(panel, {
+      legend: false,
+      legendMode: 'table',
+      legendPlacement: 'right',
+      timeseriesDrawStyle: 'bars',
+      timeseriesFillOpacity: 30,
+      timeseriesLineInterpolation: 'smooth',
+      timeseriesLineWidth: 3,
+      timeseriesPointSize: 8,
+      timeseriesShowPoints: 'always',
+      timeseriesStacking: 'normal',
+      tooltipMode: 'multi',
+      tooltipSort: 'desc',
+    });
+
+    expect(panel.fieldConfig.defaults.custom).toEqual(
+      expect.objectContaining({
+        drawStyle: 'bars',
+        fillOpacity: 30,
+        lineInterpolation: 'smooth',
+        lineWidth: 3,
+        pointSize: 8,
+        showPoints: 'always',
+        stacking: { group: 'B', mode: 'normal' },
+      })
+    );
+    expect(panel.options.legend).toEqual(
+      expect.objectContaining({
+        displayMode: 'table',
+        placement: 'right',
+        showLegend: false,
+      })
+    );
+    expect(panel.options.tooltip).toEqual({ mode: 'multi', sort: 'desc' });
+  });
+
+  it('applies bar chart layout and display options', () => {
+    const panel = getPanel('barchart');
+
+    applyOptions(panel, {
+      barFillOpacity: 75,
+      barGroupWidth: 0.6,
+      barRadius: 0.2,
+      barShowValue: 'always',
+      barStacking: 'percent',
+      barTickLabelMaxLength: 18,
+      barTickLabelRotation: -30,
+      barWidth: 0.8,
+      orientation: 'horizontal',
+    });
+
+    expect(panel.fieldConfig.defaults.custom).toEqual({ fillOpacity: 75 });
+    expect(panel.options).toEqual(
+      expect.objectContaining({
+        barRadius: 0.2,
+        barWidth: 0.8,
+        groupWidth: 0.6,
+        orientation: 'horizontal',
+        showValue: 'always',
+        stacking: 'percent',
+        xTickLabelMaxLength: 18,
+        xTickLabelRotation: -30,
+      })
+    );
+  });
+
+  it('applies pie chart labels, legend values, and tooltip options', () => {
+    const panel = getPanel('piechart');
+
+    applyOptions(panel, {
+      pieDisplayLabels: ['name', 'percent'],
+      pieLegendValues: ['value'],
+      pieType: 'donut',
+      tooltipMode: 'none',
+      tooltipSort: 'none',
+    });
+
+    expect(panel.options).toEqual(
+      expect.objectContaining({
+        displayLabels: ['name', 'percent'],
+        legend: expect.objectContaining({
+          values: ['value'],
+        }),
+        pieType: 'donut',
+        tooltip: { mode: 'none', sort: 'none' },
+      })
+    );
+  });
+});

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -3,7 +3,7 @@ import { Portal } from '@mui/material';
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps, MapDispatchToProps, MapStateToProps } from 'react-redux';
 
-import { FieldConfigSource, NavModel, NavModelItem, TimeRange, PageLayoutType, locationUtil } from '@grafana/data';
+import { NavModel, NavModelItem, TimeRange, PageLayoutType, locationUtil } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { config, locationService } from '@grafana/runtime';
 import { Themeable2, withTheme2, ToolbarButtonRow } from '@grafana/ui';
@@ -21,6 +21,7 @@ import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 import { updateTimeZoneForSession } from 'app/features/profile/state/reducers';
 import { getPageNavFromSlug, getRootContentNavModel } from 'app/features/storage/StorageFolderPage';
 import { FNDashboardProps } from 'app/fn-app/types';
+import { FnLoggerService } from 'app/fn_logger';
 import { DashboardRoutes, DashboardState, KioskMode, StoreState } from 'app/types';
 import { PanelEditEnteredEvent, PanelEditExitedEvent } from 'app/types/events';
 
@@ -43,6 +44,10 @@ import { getTimeSrv } from '../services/TimeSrv';
 import { cleanUpDashboardAndVariables } from '../state/actions';
 import { initDashboard } from '../state/initDashboard';
 import { calculateNewPanelGridPos } from '../utils/panel';
+
+import { applyFnPanelOptionsPreview } from './DashboardPageFnPanelOptions';
+
+export { applyFnPanelOptionsPreview } from './DashboardPageFnPanelOptions';
 
 export interface DashboardPageRouteParams {
   uid?: string;
@@ -72,7 +77,10 @@ export type MapStateToDashboardPageProps = MapStateToProps<
   Pick<DashboardState, 'initPhase' | 'initError'> & {
     dashboard: ReturnType<DashboardState['getModel']>;
     navIndex: StoreState['navIndex'];
-  } & Pick<FnGlobalState, 'FNDashboard' | 'controlsContainer' | 'enablePanelLayoutEdit' | 'panelOptionsUpdate'> & {
+  } & Pick<
+      FnGlobalState,
+      'FNDashboard' | 'controlsContainer' | 'dashboardAccessMode' | 'enablePanelLayoutEdit' | 'panelOptionsUpdate'
+    > & {
       dashboardEventListener: FnGlobalState['metadata']['eventListener'];
     },
   OwnProps,
@@ -96,6 +104,7 @@ export const mapStateToProps: MapStateToDashboardPageProps = (state) => ({
   navIndex: state.navIndex,
   FNDashboard: state.fnGlobalState.FNDashboard,
   controlsContainer: state.fnGlobalState.controlsContainer,
+  dashboardAccessMode: state.fnGlobalState.dashboardAccessMode,
   enablePanelLayoutEdit: state.fnGlobalState.enablePanelLayoutEdit,
   panelOptionsUpdate: state.fnGlobalState.panelOptionsUpdate,
   dashboardEventListener: state.fnGlobalState.metadata?.eventListener ?? null,
@@ -110,286 +119,6 @@ const mapDispatchToProps: MapDispatchToDashboardPageProps = {
 };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined;
-}
-
-function numberValue(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
-}
-
-function booleanValue(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined;
-}
-
-function stringArrayValue(value: unknown): string[] | undefined {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : undefined;
-}
-
-function panelFieldConfigParts(panel: PanelModel) {
-  const baseFieldConfig = panel.fieldConfig ?? ({ defaults: {}, overrides: [] } as FieldConfigSource);
-  const defaults = isRecord(baseFieldConfig.defaults) ? { ...baseFieldConfig.defaults } : {};
-  const custom = isRecord(defaults.custom) ? { ...defaults.custom } : {};
-
-  return {
-    fieldConfig: {
-      ...baseFieldConfig,
-      defaults,
-      overrides: baseFieldConfig.overrides ?? [],
-    } as FieldConfigSource,
-    defaults,
-    custom,
-  };
-}
-
-function applyFnPanelOptionsPreview(panel: PanelModel, update: FnPanelOptionsUpdate): void {
-  const draft = update.options;
-  const previousFieldConfig = JSON.stringify(panel.fieldConfig ?? { defaults: {}, overrides: [] });
-  const previousOptions = JSON.stringify(panel.options ?? {});
-  const options = isRecord(panel.options) ? { ...panel.options } : {};
-  const { fieldConfig, defaults, custom } = panelFieldConfigParts(panel);
-  let frameOptionsChanged = false;
-
-  const title = stringValue(draft.title);
-  if (title !== undefined && panel.title !== title) {
-    panel.title = title;
-    frameOptionsChanged = true;
-  }
-
-  const description = stringValue(draft.description);
-  if (description !== undefined && panel.description !== description) {
-    panel.description = description;
-    frameOptionsChanged = true;
-  }
-
-  const unit = stringValue(draft.unit);
-  if (unit !== undefined) {
-    defaults.unit = unit;
-  }
-
-  const decimals = numberValue(draft.decimals);
-  if (decimals !== undefined) {
-    defaults.decimals = decimals;
-  }
-
-  switch (panel.type) {
-    case 'stat':
-    case 'gauge': {
-      const fontSize = numberValue(draft.fontSize);
-      if (fontSize !== undefined) {
-        const text = isRecord(options.text) ? { ...options.text } : {};
-        text.valueSize = fontSize;
-        options.text = text;
-      }
-      break;
-    }
-    case 'table': {
-      const showHeader = booleanValue(draft.tableShowHeader);
-      if (showHeader !== undefined) {
-        options.showHeader = showHeader;
-      }
-
-      const cellHeight = stringValue(draft.tableCellHeight);
-      if (cellHeight !== undefined) {
-        options.cellHeight = cellHeight;
-      }
-
-      const tableColumnFilter = booleanValue(draft.tableColumnFilter);
-      if (tableColumnFilter !== undefined) {
-        custom.filterable = tableColumnFilter;
-      }
-
-      const tableSortBy = stringValue(draft.tableSortBy);
-      if (tableSortBy !== undefined) {
-        const displayName = tableSortBy.trim();
-        options.sortBy = displayName ? [{ displayName, desc: booleanValue(draft.tableSortDesc) ?? false }] : [];
-      }
-
-      const pagination = booleanValue(draft.tablePagination);
-      const footerVisible = booleanValue(draft.tableFooter);
-      if (pagination !== undefined || footerVisible !== undefined) {
-        const footer: Record<string, unknown> = isRecord(options.footer)
-          ? { ...options.footer }
-          : { countRows: false, fields: '', reducer: ['sum'], show: false };
-        if (pagination !== undefined) {
-          footer.enablePagination = pagination;
-        }
-        if (footerVisible !== undefined) {
-          footer.show = footerVisible;
-        }
-        options.footer = footer;
-      }
-      break;
-    }
-    case 'timeseries': {
-      const drawStyle = stringValue(draft.timeseriesDrawStyle);
-      if (drawStyle !== undefined) {
-        custom.drawStyle = drawStyle;
-      }
-
-      const lineInterpolation = stringValue(draft.timeseriesLineInterpolation);
-      if (lineInterpolation !== undefined) {
-        custom.lineInterpolation = lineInterpolation;
-      }
-
-      const lineWidth = numberValue(draft.timeseriesLineWidth);
-      if (lineWidth !== undefined) {
-        custom.lineWidth = lineWidth;
-      }
-
-      const fillOpacity = numberValue(draft.timeseriesFillOpacity);
-      if (fillOpacity !== undefined) {
-        custom.fillOpacity = fillOpacity;
-      }
-
-      const showPoints = stringValue(draft.timeseriesShowPoints);
-      if (showPoints !== undefined) {
-        custom.showPoints = showPoints;
-      }
-
-      const pointSize = numberValue(draft.timeseriesPointSize);
-      if (pointSize !== undefined) {
-        custom.pointSize = pointSize;
-      }
-
-      const stacking = stringValue(draft.timeseriesStacking);
-      if (stacking !== undefined) {
-        const existingStacking = isRecord(custom.stacking) ? custom.stacking : {};
-        custom.stacking = {
-          ...existingStacking,
-          group: stringValue(existingStacking.group) ?? 'A',
-          mode: stacking,
-        };
-      }
-      break;
-    }
-    case 'barchart': {
-      const orientation = stringValue(draft.orientation);
-      if (orientation !== undefined) {
-        options.orientation = orientation;
-      }
-
-      const showValue = stringValue(draft.barShowValue);
-      if (showValue !== undefined) {
-        options.showValue = showValue;
-      }
-
-      const stacking = stringValue(draft.barStacking);
-      if (stacking !== undefined) {
-        options.stacking = stacking;
-      }
-
-      const groupWidth = numberValue(draft.barGroupWidth);
-      if (groupWidth !== undefined) {
-        options.groupWidth = groupWidth;
-      }
-
-      const barWidth = numberValue(draft.barWidth);
-      if (barWidth !== undefined) {
-        options.barWidth = barWidth;
-      }
-
-      const barRadius = numberValue(draft.barRadius);
-      if (barRadius !== undefined) {
-        options.barRadius = barRadius;
-      }
-
-      const fillOpacity = numberValue(draft.barFillOpacity);
-      if (fillOpacity !== undefined) {
-        custom.fillOpacity = fillOpacity;
-      }
-
-      const tickRotation = numberValue(draft.barTickLabelRotation);
-      if (tickRotation !== undefined) {
-        options.xTickLabelRotation = tickRotation;
-      }
-
-      const tickMaxLength = numberValue(draft.barTickLabelMaxLength);
-      if (tickMaxLength !== undefined) {
-        options.xTickLabelMaxLength = tickMaxLength;
-      }
-      break;
-    }
-    case 'piechart': {
-      const pieType = stringValue(draft.pieType);
-      if (pieType !== undefined) {
-        options.pieType = pieType;
-      }
-
-      const labels = stringArrayValue(draft.pieDisplayLabels);
-      if (labels !== undefined) {
-        options.displayLabels = labels;
-      }
-      break;
-    }
-  }
-
-  if (panel.type === 'timeseries' || panel.type === 'barchart' || panel.type === 'piechart') {
-    const legend: Record<string, unknown> = isRecord(options.legend)
-      ? { ...options.legend }
-      : { calcs: [], displayMode: 'list', placement: 'bottom' };
-
-    const legendVisible = booleanValue(draft.legend);
-    if (legendVisible !== undefined) {
-      legend.showLegend = legendVisible;
-    }
-
-    const legendMode = stringValue(draft.legendMode);
-    if (legendMode !== undefined) {
-      legend.displayMode = legendMode;
-    }
-
-    const legendPlacement = stringValue(draft.legendPlacement);
-    if (legendPlacement !== undefined) {
-      legend.placement = legendPlacement;
-    }
-
-    if (panel.type === 'piechart') {
-      const legendValues = stringArrayValue(draft.pieLegendValues);
-      if (legendValues !== undefined) {
-        legend.values = legendValues;
-      }
-    }
-
-    options.legend = legend;
-
-    const tooltipMode = stringValue(draft.tooltipMode);
-    const tooltipSort = stringValue(draft.tooltipSort);
-    if (tooltipMode !== undefined || tooltipSort !== undefined) {
-      const tooltip = isRecord(options.tooltip) ? { ...options.tooltip } : { mode: 'single', sort: 'none' };
-      if (tooltipMode !== undefined) {
-        tooltip.mode = tooltipMode;
-      }
-      if (tooltipSort !== undefined) {
-        tooltip.sort = tooltipSort;
-      }
-      options.tooltip = tooltip;
-    }
-  }
-
-  defaults.custom = custom;
-  fieldConfig.defaults = defaults;
-
-  const fieldConfigChanged = JSON.stringify(fieldConfig) !== previousFieldConfig;
-  const optionsChanged = JSON.stringify(options) !== previousOptions;
-
-  if (fieldConfigChanged) {
-    panel.updateFieldConfig(fieldConfig);
-  }
-
-  if (optionsChanged) {
-    panel.updateOptions(options);
-  }
-
-  if (frameOptionsChanged && !fieldConfigChanged && !optionsChanged) {
-    panel.render();
-  }
-}
 
 type OwnProps = {
   isPublic?: boolean;
@@ -555,6 +284,11 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
   applyFnPanelOptionsUpdate(update: FnPanelOptionsUpdate) {
     const panel = this.props.dashboard?.getPanelById(update.panelId);
     if (!panel) {
+      FnLoggerService.warn('Unable to apply FN panel options update because the panel was not found', {
+        panelId: update.panelId,
+        revision: update.revision,
+        uid: this.props.dashboard?.uid,
+      });
       return;
     }
 
@@ -664,16 +398,26 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
     return this.props.dashboard?.getSaveModelClone();
   }
 
+  emitFnDashboardEvent<T>(type: string, data: T): void {
+    const listener = this.props.dashboardEventListener;
+    if (!listener) {
+      return;
+    }
+
+    try {
+      listener({ type, data });
+    } catch (error) {
+      FnLoggerService.warn('FN dashboard event listener failed', { error, type });
+    }
+  }
+
   onFnDashboardLayoutChange = () => {
     const dashboardJson = this.getFnDashboardSaveModel();
     if (!dashboardJson) {
       return;
     }
 
-    this.props.dashboardEventListener?.({
-      type: 'dashboardLayoutChanged',
-      data: dashboardJson,
-    });
+    this.emitFnDashboardEvent('dashboardLayoutChanged', dashboardJson);
   };
 
   getInspectPanel() {
@@ -696,7 +440,15 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
   }
 
   render() {
-    const { dashboard, initError, queryParams, FNDashboard, controlsContainer, enablePanelLayoutEdit } = this.props;
+    const {
+      dashboard,
+      initError,
+      queryParams,
+      FNDashboard,
+      controlsContainer,
+      dashboardAccessMode,
+      enablePanelLayoutEdit,
+    } = this.props;
     const { editPanel, viewPanel, pageNav, sectionNav } = this.state;
     const kioskMode = getKioskMode(this.props.queryParams);
 
@@ -710,7 +462,8 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
     const showSubMenu = !editPanel && !kioskMode && !this.props.queryParams.editview;
 
     const showToolbar = FNDashboard || (kioskMode !== KioskMode.Full && !queryParams.editview);
-    const isCustomFnDashboardLayoutEditable = FNDashboard && enablePanelLayoutEdit && !viewPanel && !editPanel;
+    const isCustomFnDashboardLayoutEditable =
+      FNDashboard && dashboardAccessMode === 'custom' && enablePanelLayoutEdit && !viewPanel && !editPanel;
     const isDashboardGridLayoutEditable = FNDashboard
       ? isCustomFnDashboardLayoutEditable
       : Boolean(dashboard.meta.canEdit);

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -3,7 +3,7 @@ import { Portal } from '@mui/material';
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps, MapDispatchToProps, MapStateToProps } from 'react-redux';
 
-import { NavModel, NavModelItem, TimeRange, PageLayoutType, locationUtil } from '@grafana/data';
+import { FieldConfigSource, NavModel, NavModelItem, TimeRange, PageLayoutType, locationUtil } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { config, locationService } from '@grafana/runtime';
 import { Themeable2, withTheme2, ToolbarButtonRow } from '@grafana/ui';
@@ -14,7 +14,7 @@ import { GrafanaContext, GrafanaContextType } from 'app/core/context/GrafanaCont
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { getKioskMode } from 'app/core/navigation/kiosk';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
-import { FnGlobalState } from 'app/core/reducers/fn-slice';
+import { FnGlobalState, FnPanelOptionsUpdate } from 'app/core/reducers/fn-slice';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { PanelModel } from 'app/features/dashboard/state';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
@@ -72,7 +72,7 @@ export type MapStateToDashboardPageProps = MapStateToProps<
   Pick<DashboardState, 'initPhase' | 'initError'> & {
     dashboard: ReturnType<DashboardState['getModel']>;
     navIndex: StoreState['navIndex'];
-  } & Pick<FnGlobalState, 'FNDashboard' | 'controlsContainer' | 'enablePanelLayoutEdit'> & {
+  } & Pick<FnGlobalState, 'FNDashboard' | 'controlsContainer' | 'enablePanelLayoutEdit' | 'panelOptionsUpdate'> & {
       dashboardEventListener: FnGlobalState['metadata']['eventListener'];
     },
   OwnProps,
@@ -97,6 +97,7 @@ export const mapStateToProps: MapStateToDashboardPageProps = (state) => ({
   FNDashboard: state.fnGlobalState.FNDashboard,
   controlsContainer: state.fnGlobalState.controlsContainer,
   enablePanelLayoutEdit: state.fnGlobalState.enablePanelLayoutEdit,
+  panelOptionsUpdate: state.fnGlobalState.panelOptionsUpdate,
   dashboardEventListener: state.fnGlobalState.metadata?.eventListener ?? null,
 });
 
@@ -109,6 +110,286 @@ const mapDispatchToProps: MapDispatchToDashboardPageProps = {
 };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function stringArrayValue(value: unknown): string[] | undefined {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : undefined;
+}
+
+function panelFieldConfigParts(panel: PanelModel) {
+  const baseFieldConfig = panel.fieldConfig ?? ({ defaults: {}, overrides: [] } as FieldConfigSource);
+  const defaults = isRecord(baseFieldConfig.defaults) ? { ...baseFieldConfig.defaults } : {};
+  const custom = isRecord(defaults.custom) ? { ...defaults.custom } : {};
+
+  return {
+    fieldConfig: {
+      ...baseFieldConfig,
+      defaults,
+      overrides: baseFieldConfig.overrides ?? [],
+    } as FieldConfigSource,
+    defaults,
+    custom,
+  };
+}
+
+function applyFnPanelOptionsPreview(panel: PanelModel, update: FnPanelOptionsUpdate): void {
+  const draft = update.options;
+  const previousFieldConfig = JSON.stringify(panel.fieldConfig ?? { defaults: {}, overrides: [] });
+  const previousOptions = JSON.stringify(panel.options ?? {});
+  const options = isRecord(panel.options) ? { ...panel.options } : {};
+  const { fieldConfig, defaults, custom } = panelFieldConfigParts(panel);
+  let frameOptionsChanged = false;
+
+  const title = stringValue(draft.title);
+  if (title !== undefined && panel.title !== title) {
+    panel.title = title;
+    frameOptionsChanged = true;
+  }
+
+  const description = stringValue(draft.description);
+  if (description !== undefined && panel.description !== description) {
+    panel.description = description;
+    frameOptionsChanged = true;
+  }
+
+  const unit = stringValue(draft.unit);
+  if (unit !== undefined) {
+    defaults.unit = unit;
+  }
+
+  const decimals = numberValue(draft.decimals);
+  if (decimals !== undefined) {
+    defaults.decimals = decimals;
+  }
+
+  switch (panel.type) {
+    case 'stat':
+    case 'gauge': {
+      const fontSize = numberValue(draft.fontSize);
+      if (fontSize !== undefined) {
+        const text = isRecord(options.text) ? { ...options.text } : {};
+        text.valueSize = fontSize;
+        options.text = text;
+      }
+      break;
+    }
+    case 'table': {
+      const showHeader = booleanValue(draft.tableShowHeader);
+      if (showHeader !== undefined) {
+        options.showHeader = showHeader;
+      }
+
+      const cellHeight = stringValue(draft.tableCellHeight);
+      if (cellHeight !== undefined) {
+        options.cellHeight = cellHeight;
+      }
+
+      const tableColumnFilter = booleanValue(draft.tableColumnFilter);
+      if (tableColumnFilter !== undefined) {
+        custom.filterable = tableColumnFilter;
+      }
+
+      const tableSortBy = stringValue(draft.tableSortBy);
+      if (tableSortBy !== undefined) {
+        const displayName = tableSortBy.trim();
+        options.sortBy = displayName ? [{ displayName, desc: booleanValue(draft.tableSortDesc) ?? false }] : [];
+      }
+
+      const pagination = booleanValue(draft.tablePagination);
+      const footerVisible = booleanValue(draft.tableFooter);
+      if (pagination !== undefined || footerVisible !== undefined) {
+        const footer: Record<string, unknown> = isRecord(options.footer)
+          ? { ...options.footer }
+          : { countRows: false, fields: '', reducer: ['sum'], show: false };
+        if (pagination !== undefined) {
+          footer.enablePagination = pagination;
+        }
+        if (footerVisible !== undefined) {
+          footer.show = footerVisible;
+        }
+        options.footer = footer;
+      }
+      break;
+    }
+    case 'timeseries': {
+      const drawStyle = stringValue(draft.timeseriesDrawStyle);
+      if (drawStyle !== undefined) {
+        custom.drawStyle = drawStyle;
+      }
+
+      const lineInterpolation = stringValue(draft.timeseriesLineInterpolation);
+      if (lineInterpolation !== undefined) {
+        custom.lineInterpolation = lineInterpolation;
+      }
+
+      const lineWidth = numberValue(draft.timeseriesLineWidth);
+      if (lineWidth !== undefined) {
+        custom.lineWidth = lineWidth;
+      }
+
+      const fillOpacity = numberValue(draft.timeseriesFillOpacity);
+      if (fillOpacity !== undefined) {
+        custom.fillOpacity = fillOpacity;
+      }
+
+      const showPoints = stringValue(draft.timeseriesShowPoints);
+      if (showPoints !== undefined) {
+        custom.showPoints = showPoints;
+      }
+
+      const pointSize = numberValue(draft.timeseriesPointSize);
+      if (pointSize !== undefined) {
+        custom.pointSize = pointSize;
+      }
+
+      const stacking = stringValue(draft.timeseriesStacking);
+      if (stacking !== undefined) {
+        const existingStacking = isRecord(custom.stacking) ? custom.stacking : {};
+        custom.stacking = {
+          ...existingStacking,
+          group: stringValue(existingStacking.group) ?? 'A',
+          mode: stacking,
+        };
+      }
+      break;
+    }
+    case 'barchart': {
+      const orientation = stringValue(draft.orientation);
+      if (orientation !== undefined) {
+        options.orientation = orientation;
+      }
+
+      const showValue = stringValue(draft.barShowValue);
+      if (showValue !== undefined) {
+        options.showValue = showValue;
+      }
+
+      const stacking = stringValue(draft.barStacking);
+      if (stacking !== undefined) {
+        options.stacking = stacking;
+      }
+
+      const groupWidth = numberValue(draft.barGroupWidth);
+      if (groupWidth !== undefined) {
+        options.groupWidth = groupWidth;
+      }
+
+      const barWidth = numberValue(draft.barWidth);
+      if (barWidth !== undefined) {
+        options.barWidth = barWidth;
+      }
+
+      const barRadius = numberValue(draft.barRadius);
+      if (barRadius !== undefined) {
+        options.barRadius = barRadius;
+      }
+
+      const fillOpacity = numberValue(draft.barFillOpacity);
+      if (fillOpacity !== undefined) {
+        custom.fillOpacity = fillOpacity;
+      }
+
+      const tickRotation = numberValue(draft.barTickLabelRotation);
+      if (tickRotation !== undefined) {
+        options.xTickLabelRotation = tickRotation;
+      }
+
+      const tickMaxLength = numberValue(draft.barTickLabelMaxLength);
+      if (tickMaxLength !== undefined) {
+        options.xTickLabelMaxLength = tickMaxLength;
+      }
+      break;
+    }
+    case 'piechart': {
+      const pieType = stringValue(draft.pieType);
+      if (pieType !== undefined) {
+        options.pieType = pieType;
+      }
+
+      const labels = stringArrayValue(draft.pieDisplayLabels);
+      if (labels !== undefined) {
+        options.displayLabels = labels;
+      }
+      break;
+    }
+  }
+
+  if (panel.type === 'timeseries' || panel.type === 'barchart' || panel.type === 'piechart') {
+    const legend: Record<string, unknown> = isRecord(options.legend)
+      ? { ...options.legend }
+      : { calcs: [], displayMode: 'list', placement: 'bottom' };
+
+    const legendVisible = booleanValue(draft.legend);
+    if (legendVisible !== undefined) {
+      legend.showLegend = legendVisible;
+    }
+
+    const legendMode = stringValue(draft.legendMode);
+    if (legendMode !== undefined) {
+      legend.displayMode = legendMode;
+    }
+
+    const legendPlacement = stringValue(draft.legendPlacement);
+    if (legendPlacement !== undefined) {
+      legend.placement = legendPlacement;
+    }
+
+    if (panel.type === 'piechart') {
+      const legendValues = stringArrayValue(draft.pieLegendValues);
+      if (legendValues !== undefined) {
+        legend.values = legendValues;
+      }
+    }
+
+    options.legend = legend;
+
+    const tooltipMode = stringValue(draft.tooltipMode);
+    const tooltipSort = stringValue(draft.tooltipSort);
+    if (tooltipMode !== undefined || tooltipSort !== undefined) {
+      const tooltip = isRecord(options.tooltip) ? { ...options.tooltip } : { mode: 'single', sort: 'none' };
+      if (tooltipMode !== undefined) {
+        tooltip.mode = tooltipMode;
+      }
+      if (tooltipSort !== undefined) {
+        tooltip.sort = tooltipSort;
+      }
+      options.tooltip = tooltip;
+    }
+  }
+
+  defaults.custom = custom;
+  fieldConfig.defaults = defaults;
+
+  const fieldConfigChanged = JSON.stringify(fieldConfig) !== previousFieldConfig;
+  const optionsChanged = JSON.stringify(options) !== previousOptions;
+
+  if (fieldConfigChanged) {
+    panel.updateFieldConfig(fieldConfig);
+  }
+
+  if (optionsChanged) {
+    panel.updateOptions(options);
+  }
+
+  if (frameOptionsChanged && !fieldConfigChanged && !optionsChanged) {
+    panel.render();
+  }
+}
 
 type OwnProps = {
   isPublic?: boolean;
@@ -200,6 +481,16 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
       return;
     }
 
+    if (
+      FNDashboard &&
+      this.props.panelOptionsUpdate &&
+      (prevProps.dashboard !== this.props.dashboard ||
+        prevProps.panelOptionsUpdate?.panelId !== this.props.panelOptionsUpdate.panelId ||
+        prevProps.panelOptionsUpdate?.revision !== this.props.panelOptionsUpdate.revision)
+    ) {
+      this.applyFnPanelOptionsUpdate(this.props.panelOptionsUpdate);
+    }
+
     if (!FNDashboard) {
       const routeReloadCounter = (this.props.history.location?.state as any)?.routeReloadCounter;
 
@@ -259,6 +550,15 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
       this.props.notifyApp(createErrorNotification(`Panel not found`));
       locationService.partial({ editPanel: null, viewPanel: null });
     }
+  }
+
+  applyFnPanelOptionsUpdate(update: FnPanelOptionsUpdate) {
+    const panel = this.props.dashboard?.getPanelById(update.panelId);
+    if (!panel) {
+      return;
+    }
+
+    applyFnPanelOptionsPreview(panel, update);
   }
 
   updateLiveTimer = () => {

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -72,7 +72,9 @@ export type MapStateToDashboardPageProps = MapStateToProps<
   Pick<DashboardState, 'initPhase' | 'initError'> & {
     dashboard: ReturnType<DashboardState['getModel']>;
     navIndex: StoreState['navIndex'];
-  } & Pick<FnGlobalState, 'FNDashboard' | 'controlsContainer'>,
+  } & Pick<FnGlobalState, 'FNDashboard' | 'controlsContainer' | 'enablePanelLayoutEdit'> & {
+      dashboardEventListener: FnGlobalState['metadata']['eventListener'];
+    },
   OwnProps,
   StoreState
 >;
@@ -94,6 +96,8 @@ export const mapStateToProps: MapStateToDashboardPageProps = (state) => ({
   navIndex: state.navIndex,
   FNDashboard: state.fnGlobalState.FNDashboard,
   controlsContainer: state.fnGlobalState.controlsContainer,
+  enablePanelLayoutEdit: state.fnGlobalState.enablePanelLayoutEdit,
+  dashboardEventListener: state.fnGlobalState.metadata?.eventListener ?? null,
 });
 
 const mapDispatchToProps: MapDispatchToDashboardPageProps = {
@@ -356,6 +360,22 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
     this.setState({ scrollElement });
   };
 
+  getFnDashboardSaveModel() {
+    return this.props.dashboard?.getSaveModelClone();
+  }
+
+  onFnDashboardLayoutChange = () => {
+    const dashboardJson = this.getFnDashboardSaveModel();
+    if (!dashboardJson) {
+      return;
+    }
+
+    this.props.dashboardEventListener?.({
+      type: 'dashboardLayoutChanged',
+      data: dashboardJson,
+    });
+  };
+
   getInspectPanel() {
     const { dashboard, queryParams } = this.props;
 
@@ -376,7 +396,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
   }
 
   render() {
-    const { dashboard, initError, queryParams, FNDashboard, controlsContainer } = this.props;
+    const { dashboard, initError, queryParams, FNDashboard, controlsContainer, enablePanelLayoutEdit } = this.props;
     const { editPanel, viewPanel, pageNav, sectionNav } = this.state;
     const kioskMode = getKioskMode(this.props.queryParams);
 
@@ -390,6 +410,18 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
     const showSubMenu = !editPanel && !kioskMode && !this.props.queryParams.editview;
 
     const showToolbar = FNDashboard || (kioskMode !== KioskMode.Full && !queryParams.editview);
+    const isCustomFnDashboardLayoutEditable = FNDashboard && enablePanelLayoutEdit && !viewPanel && !editPanel;
+    const isDashboardGridLayoutEditable = FNDashboard
+      ? isCustomFnDashboardLayoutEditable
+      : Boolean(dashboard.meta.canEdit);
+    const fnControlsClassName = cx(
+      'flex w-full gap-y-2',
+      viewPanel
+        ? 'flex-row items-start justify-between gap-x-3'
+        : 'flex-col-reverse md:flex-row md:items-center md:justify-between'
+    );
+    const fnVariablesClassName = cx('flex items-center', viewPanel ? 'min-w-0 flex-1' : 'w-full');
+    const fnTimeRangeClassName = cx('flex items-center justify-end gap-2', viewPanel ? 'shrink-0' : 'w-full');
 
     const pageClassName = cx({
       'panel-in-fullscreen': Boolean(viewPanel),
@@ -455,15 +487,15 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
           {!FNDashboard && <DashboardPrompt dashboard={dashboard} />}
           {initError && <DashboardFailed />}
           {FNDashboard && (
-            <div className="flex flex-col-reverse md:flex-row md:items-center md:justify-between w-full gap-y-2">
-              <div className="flex items-center w-full">
+            <div className={fnControlsClassName}>
+              <div className={fnVariablesClassName}>
                 {showSubMenu && (
                   <section aria-label={selectors.pages.Dashboard.SubMenu.submenu}>
                     <SubMenu dashboard={dashboard} annotations={dashboard.annotations.list} links={dashboard.links} />
                   </section>
                 )}
               </div>
-              <div className="flex items-center w-full justify-end">{FNTimeRange}</div>
+              <div className={fnTimeRangeClassName}>{FNTimeRange}</div>
             </div>
           )}
           {showSubMenu && !FNDashboard && (
@@ -474,6 +506,8 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
           <DashboardGrid
             dashboard={dashboard}
             isEditable={!!dashboard.meta.canEdit && !FNDashboard}
+            isLayoutEditable={isDashboardGridLayoutEditable}
+            onLayoutUpdate={isCustomFnDashboardLayoutEditable ? this.onFnDashboardLayoutChange : undefined}
             viewPanel={viewPanel}
             editPanel={editPanel}
           />

--- a/public/app/features/dashboard/containers/DashboardPageFnPanelOptions.ts
+++ b/public/app/features/dashboard/containers/DashboardPageFnPanelOptions.ts
@@ -1,0 +1,322 @@
+import type { FieldConfigSource } from '@grafana/data';
+import type { FnPanelOptionsUpdate } from 'app/core/reducers/fn-slice';
+import type { PanelModel } from 'app/features/dashboard/state';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function stringArrayValue(value: unknown): string[] | undefined {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : undefined;
+}
+
+interface PanelFieldConfigParts {
+  readonly custom: Record<string, unknown>;
+  readonly defaults: Record<string, unknown>;
+  readonly fieldConfig: FieldConfigSource;
+}
+
+const EMPTY_FIELD_CONFIG: FieldConfigSource = {
+  defaults: {},
+  overrides: [],
+};
+
+function panelFieldConfigParts(panel: PanelModel): PanelFieldConfigParts {
+  const baseFieldConfig = panel.fieldConfig ?? EMPTY_FIELD_CONFIG;
+  const defaults = isRecord(baseFieldConfig.defaults) ? { ...baseFieldConfig.defaults } : {};
+  const custom = isRecord(defaults.custom) ? { ...defaults.custom } : {};
+  const fieldConfig: FieldConfigSource = {
+    ...baseFieldConfig,
+    defaults,
+    overrides: baseFieldConfig.overrides ?? [],
+  };
+
+  return {
+    custom,
+    defaults,
+    fieldConfig,
+  };
+}
+
+function supportsLegendAndTooltip(panel: PanelModel): boolean {
+  return panel.type === 'timeseries' || panel.type === 'barchart' || panel.type === 'piechart';
+}
+
+function applyLegendOptions(
+  panel: PanelModel,
+  options: Record<string, unknown>,
+  draft: Readonly<Record<string, unknown>>
+): void {
+  const legend: Record<string, unknown> = isRecord(options.legend)
+    ? { ...options.legend }
+    : { calcs: [], displayMode: 'list', placement: 'bottom' };
+
+  const legendVisible = booleanValue(draft.legend);
+  if (legendVisible !== undefined) {
+    legend.showLegend = legendVisible;
+  }
+
+  const legendMode = stringValue(draft.legendMode);
+  if (legendMode !== undefined) {
+    legend.displayMode = legendMode;
+  }
+
+  const legendPlacement = stringValue(draft.legendPlacement);
+  if (legendPlacement !== undefined) {
+    legend.placement = legendPlacement;
+  }
+
+  if (panel.type === 'piechart') {
+    const legendValues = stringArrayValue(draft.pieLegendValues);
+    if (legendValues !== undefined) {
+      legend.values = legendValues;
+    }
+  }
+
+  options.legend = legend;
+}
+
+function applyTooltipOptions(options: Record<string, unknown>, draft: Readonly<Record<string, unknown>>): void {
+  const tooltipMode = stringValue(draft.tooltipMode);
+  const tooltipSort = stringValue(draft.tooltipSort);
+  if (tooltipMode === undefined && tooltipSort === undefined) {
+    return;
+  }
+
+  const tooltip = isRecord(options.tooltip) ? { ...options.tooltip } : { mode: 'single', sort: 'none' };
+  if (tooltipMode !== undefined) {
+    tooltip.mode = tooltipMode;
+  }
+  if (tooltipSort !== undefined) {
+    tooltip.sort = tooltipSort;
+  }
+  options.tooltip = tooltip;
+}
+
+function applySharedGraphOptions(
+  panel: PanelModel,
+  options: Record<string, unknown>,
+  draft: Readonly<Record<string, unknown>>
+): void {
+  if (!supportsLegendAndTooltip(panel)) {
+    return;
+  }
+
+  applyLegendOptions(panel, options, draft);
+  applyTooltipOptions(options, draft);
+}
+
+export function applyFnPanelOptionsPreview(panel: PanelModel, update: FnPanelOptionsUpdate): void {
+  const draft = update.options;
+  const previousFieldConfig = JSON.stringify(panel.fieldConfig ?? { defaults: {}, overrides: [] });
+  const previousOptions = JSON.stringify(panel.options ?? {});
+  const options = isRecord(panel.options) ? { ...panel.options } : {};
+  const { fieldConfig, defaults, custom } = panelFieldConfigParts(panel);
+  let frameOptionsChanged = false;
+
+  const title = stringValue(draft.title);
+  if (title !== undefined && panel.title !== title) {
+    panel.title = title;
+    frameOptionsChanged = true;
+  }
+
+  const description = stringValue(draft.description);
+  if (description !== undefined && panel.description !== description) {
+    panel.description = description;
+    frameOptionsChanged = true;
+  }
+
+  const unit = stringValue(draft.unit);
+  if (unit !== undefined) {
+    defaults.unit = unit;
+  }
+
+  const decimals = numberValue(draft.decimals);
+  if (decimals !== undefined) {
+    defaults.decimals = decimals;
+  }
+
+  switch (panel.type) {
+    case 'stat':
+    case 'gauge': {
+      const fontSize = numberValue(draft.fontSize);
+      if (fontSize !== undefined) {
+        const text = isRecord(options.text) ? { ...options.text } : {};
+        text.valueSize = fontSize;
+        options.text = text;
+      }
+      break;
+    }
+    case 'table': {
+      const showHeader = booleanValue(draft.tableShowHeader);
+      if (showHeader !== undefined) {
+        options.showHeader = showHeader;
+      }
+
+      const cellHeight = stringValue(draft.tableCellHeight);
+      if (cellHeight !== undefined) {
+        options.cellHeight = cellHeight;
+      }
+
+      const tableColumnFilter = booleanValue(draft.tableColumnFilter);
+      if (tableColumnFilter !== undefined) {
+        custom.filterable = tableColumnFilter;
+      }
+
+      const tableSortBy = stringValue(draft.tableSortBy);
+      if (tableSortBy !== undefined) {
+        const displayName = tableSortBy.trim();
+        options.sortBy = displayName ? [{ displayName, desc: booleanValue(draft.tableSortDesc) ?? false }] : [];
+      }
+
+      const pagination = booleanValue(draft.tablePagination);
+      const footerVisible = booleanValue(draft.tableFooter);
+      if (pagination !== undefined || footerVisible !== undefined) {
+        const footer: Record<string, unknown> = isRecord(options.footer)
+          ? { ...options.footer }
+          : { countRows: false, fields: '', reducer: ['sum'], show: false };
+        if (pagination !== undefined) {
+          footer.enablePagination = pagination;
+        }
+        if (footerVisible !== undefined) {
+          footer.show = footerVisible;
+        }
+        options.footer = footer;
+      }
+      break;
+    }
+    case 'timeseries': {
+      const drawStyle = stringValue(draft.timeseriesDrawStyle);
+      if (drawStyle !== undefined) {
+        custom.drawStyle = drawStyle;
+      }
+
+      const lineInterpolation = stringValue(draft.timeseriesLineInterpolation);
+      if (lineInterpolation !== undefined) {
+        custom.lineInterpolation = lineInterpolation;
+      }
+
+      const lineWidth = numberValue(draft.timeseriesLineWidth);
+      if (lineWidth !== undefined) {
+        custom.lineWidth = lineWidth;
+      }
+
+      const fillOpacity = numberValue(draft.timeseriesFillOpacity);
+      if (fillOpacity !== undefined) {
+        custom.fillOpacity = fillOpacity;
+      }
+
+      const showPoints = stringValue(draft.timeseriesShowPoints);
+      if (showPoints !== undefined) {
+        custom.showPoints = showPoints;
+      }
+
+      const pointSize = numberValue(draft.timeseriesPointSize);
+      if (pointSize !== undefined) {
+        custom.pointSize = pointSize;
+      }
+
+      const stacking = stringValue(draft.timeseriesStacking);
+      if (stacking !== undefined) {
+        const existingStacking = isRecord(custom.stacking) ? custom.stacking : {};
+        custom.stacking = {
+          ...existingStacking,
+          group: stringValue(existingStacking.group) ?? 'A',
+          mode: stacking,
+        };
+      }
+      break;
+    }
+    case 'barchart': {
+      const orientation = stringValue(draft.orientation);
+      if (orientation !== undefined) {
+        options.orientation = orientation;
+      }
+
+      const showValue = stringValue(draft.barShowValue);
+      if (showValue !== undefined) {
+        options.showValue = showValue;
+      }
+
+      const stacking = stringValue(draft.barStacking);
+      if (stacking !== undefined) {
+        options.stacking = stacking;
+      }
+
+      const groupWidth = numberValue(draft.barGroupWidth);
+      if (groupWidth !== undefined) {
+        options.groupWidth = groupWidth;
+      }
+
+      const barWidth = numberValue(draft.barWidth);
+      if (barWidth !== undefined) {
+        options.barWidth = barWidth;
+      }
+
+      const barRadius = numberValue(draft.barRadius);
+      if (barRadius !== undefined) {
+        options.barRadius = barRadius;
+      }
+
+      const fillOpacity = numberValue(draft.barFillOpacity);
+      if (fillOpacity !== undefined) {
+        custom.fillOpacity = fillOpacity;
+      }
+
+      const tickRotation = numberValue(draft.barTickLabelRotation);
+      if (tickRotation !== undefined) {
+        options.xTickLabelRotation = tickRotation;
+      }
+
+      const tickMaxLength = numberValue(draft.barTickLabelMaxLength);
+      if (tickMaxLength !== undefined) {
+        options.xTickLabelMaxLength = tickMaxLength;
+      }
+      break;
+    }
+    case 'piechart': {
+      const pieType = stringValue(draft.pieType);
+      if (pieType !== undefined) {
+        options.pieType = pieType;
+      }
+
+      const labels = stringArrayValue(draft.pieDisplayLabels);
+      if (labels !== undefined) {
+        options.displayLabels = labels;
+      }
+      break;
+    }
+  }
+
+  applySharedGraphOptions(panel, options, draft);
+
+  defaults.custom = custom;
+  fieldConfig.defaults = defaults;
+
+  const fieldConfigChanged = JSON.stringify(fieldConfig) !== previousFieldConfig;
+  const optionsChanged = JSON.stringify(options) !== previousOptions;
+
+  if (fieldConfigChanged) {
+    panel.updateFieldConfig(fieldConfig);
+  }
+
+  if (optionsChanged) {
+    panel.updateOptions(options);
+  }
+
+  if (frameOptionsChanged && !fieldConfigChanged && !optionsChanged) {
+    panel.render();
+  }
+}

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.test.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.test.tsx
@@ -8,6 +8,7 @@ import { TextBoxVariableModel } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
 import appEvents from 'app/core/app_events';
+import { GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from 'app/core/constants';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 import { GetVariables } from 'app/features/variables/state/selectors';
 import { VariablesChanged } from 'app/features/variables/types';
@@ -17,7 +18,7 @@ import { DashboardMeta } from 'app/types';
 import { DashboardModel } from '../state';
 import { createDashboardModelFixture } from '../state/__fixtures__/dashboardFixtures';
 
-import { DashboardGrid, Props } from './DashboardGrid';
+import { Component, DashboardGrid, Props } from './DashboardGrid';
 import { Props as LazyLoaderProps } from './LazyLoader';
 
 jest.mock('@grafana/runtime', () => ({
@@ -53,6 +54,21 @@ function setup(props: Props) {
       </Provider>
     </GrafanaContext.Provider>
   );
+}
+
+function getRect(overrides: Partial<DOMRect>): DOMRect {
+  return {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    toJSON: () => ({}),
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+    ...overrides,
+  };
 }
 
 function getTestDashboard(
@@ -113,6 +129,96 @@ describe('DashboardGrid', () => {
     expect(await screen.findByText('My table')).toBeInTheDocument();
     expect(await screen.findByText('My table 2')).toBeInTheDocument();
     expect(await screen.findByText('My gauge')).toBeInTheDocument();
+  });
+
+  it('Should render only the selected panel in embedded view-panel mode', async () => {
+    const dashboard = getTestDashboard();
+    const viewPanel = dashboard.getPanelById(2);
+    dashboard.initViewPanel(viewPanel);
+
+    const props: Props = {
+      editPanel: null,
+      viewPanel,
+      isEditable: false,
+      isFnDashboard: true,
+      portalContainerID: 'grafana-portal',
+      dashboard,
+    };
+
+    act(() => {
+      setup(props);
+    });
+
+    expect(await screen.findByText('My table')).toBeInTheDocument();
+    expect(screen.queryByText('My graph')).toBeNull();
+    expect(screen.queryByText('My table 2')).toBeNull();
+    expect(screen.queryByText('My gauge')).toBeNull();
+  });
+
+  it('Should normalize selected panel layout in embedded view-panel mode without changing the dashboard model', () => {
+    const dashboard = getTestDashboard();
+    const viewPanel = dashboard.getPanelById(2);
+    const originalGridPos = { x: 12, y: 10, w: 12, h: 10 };
+    viewPanel.gridPos = { ...originalGridPos };
+    dashboard.initViewPanel(viewPanel);
+
+    const props: Props = {
+      editPanel: null,
+      viewPanel,
+      isEditable: false,
+      isFnDashboard: true,
+      portalContainerID: 'grafana-portal',
+      dashboard,
+    };
+
+    const grid = new Component(props);
+    const layout = grid.buildLayout();
+    const panelLayout = layout[0]!;
+
+    expect(layout).toHaveLength(1);
+    expect(panelLayout).toEqual(
+      expect.objectContaining({
+        x: 0,
+        y: 0,
+        w: GRID_COLUMN_COUNT,
+        h: originalGridPos.h,
+      })
+    );
+
+    grid.onLayoutChange([{ ...panelLayout, x: 8, y: 5, w: 8, h: 8 }]);
+
+    expect(viewPanel.gridPos).toEqual(originalGridPos);
+  });
+
+  it('Should measure embedded view-panel height below dashboard controls', () => {
+    const dashboard = getTestDashboard();
+    const viewPanel = dashboard.getPanelById(2);
+    dashboard.initViewPanel(viewPanel);
+    const portal = document.createElement('div');
+    const gridWrapper = document.createElement('div');
+    portal.id = 'grafana-portal';
+    portal.appendChild(gridWrapper);
+    document.body.appendChild(portal);
+
+    jest.spyOn(portal, 'getBoundingClientRect').mockReturnValue(getRect({ bottom: 680, height: 575, top: 105 }));
+    jest.spyOn(gridWrapper, 'getBoundingClientRect').mockReturnValue(getRect({ bottom: 541, height: 372, top: 169 }));
+
+    const props: Props = {
+      editPanel: null,
+      viewPanel,
+      isEditable: false,
+      isFnDashboard: true,
+      portalContainerID: portal.id,
+      dashboard,
+    };
+    const grid = new Component(props);
+    Object.defineProperty(grid, 'gridWrapperElement', {
+      value: gridWrapper,
+    });
+
+    expect(grid.getEmbeddedViewPanelHeight()).toBe(680 - 169 - GRID_CELL_VMARGIN);
+
+    portal.remove();
   });
 
   it('Should allow filtering panels', async () => {

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -84,6 +84,7 @@ export class Component extends PureComponent<Props, State> {
   private portalResizeObserver?: ResizeObserver;
   private gridWrapperElement?: HTMLDivElement;
   private embeddedHeightMeasureAnimationFrame?: number;
+  private embeddedViewPanelMeasureRetryTimeout?: ReturnType<typeof setTimeout>;
 
   constructor(props: Props) {
     super(props);
@@ -111,6 +112,10 @@ export class Component extends PureComponent<Props, State> {
         cancelAnimationFrame(this.embeddedHeightMeasureAnimationFrame);
       }
       this.embeddedHeightMeasureAnimationFrame = undefined;
+    }
+    if (this.embeddedViewPanelMeasureRetryTimeout !== undefined) {
+      clearTimeout(this.embeddedViewPanelMeasureRetryTimeout);
+      this.embeddedViewPanelMeasureRetryTimeout = undefined;
     }
   }
 
@@ -147,6 +152,8 @@ export class Component extends PureComponent<Props, State> {
     if (height !== undefined && height > 0 && height !== this.state.viewPanelHeight) {
       this.setState({ viewPanelHeight: height });
     }
+
+    this.scheduleEmbeddedViewPanelMeasureRetry();
   }
 
   scheduleEmbeddedViewPanelHeightMeasure = () => {
@@ -178,6 +185,40 @@ export class Component extends PureComponent<Props, State> {
     this.embeddedHeightMeasureAnimationFrame = requestAnimationFrame(measureHeight);
   };
 
+  scheduleEmbeddedViewPanelMeasureRetry = (attempt = 0) => {
+    if (this.embeddedViewPanelMeasureRetryTimeout !== undefined) {
+      clearTimeout(this.embeddedViewPanelMeasureRetryTimeout);
+      this.embeddedViewPanelMeasureRetryTimeout = undefined;
+    }
+
+    if (!this.props.isFnDashboard || !this.props.viewPanel) {
+      return;
+    }
+
+    this.embeddedViewPanelMeasureRetryTimeout = setTimeout(() => {
+      this.embeddedViewPanelMeasureRetryTimeout = undefined;
+
+      if (!this.props.isFnDashboard || !this.props.viewPanel) {
+        return;
+      }
+
+      const width = this.measureEmbeddedViewPanelWidth();
+      const height = this.measureEmbeddedViewPanelHeight();
+      if (width !== undefined && height !== undefined) {
+        if (height !== this.state.viewPanelHeight) {
+          this.setState({ viewPanelHeight: height });
+        } else {
+          this.forceUpdate();
+        }
+        return;
+      }
+
+      if (attempt < 120) {
+        this.scheduleEmbeddedViewPanelMeasureRetry(attempt + 1);
+      }
+    }, 250);
+  };
+
   measureEmbeddedViewPanelHeight(): number | undefined {
     if (!this.props.isFnDashboard || !this.props.viewPanel || !this.props.portalContainerID) {
       return undefined;
@@ -199,6 +240,30 @@ export class Component extends PureComponent<Props, State> {
     const availableHeight = Math.floor(portalRect.bottom - gridRect.top - GRID_CELL_VMARGIN);
 
     return availableHeight > 0 ? availableHeight : undefined;
+  }
+
+  measureEmbeddedViewPanelWidth(): number | undefined {
+    if (!this.props.isFnDashboard || !this.props.viewPanel || !this.props.portalContainerID) {
+      return undefined;
+    }
+
+    const portalContainer = document.getElementById(this.props.portalContainerID);
+    if (!portalContainer) {
+      return undefined;
+    }
+
+    const scrollContainer = portalContainer.querySelector<HTMLElement>('#page-scrollbar');
+    const canvasContent =
+      scrollContainer?.firstElementChild instanceof HTMLElement ? scrollContainer.firstElementChild : undefined;
+    const widthElement = canvasContent ?? portalContainer;
+    const widthElementStyle = getComputedStyle(widthElement);
+    const horizontalPadding =
+      parseFloat(widthElementStyle.paddingLeft || '0') + parseFloat(widthElementStyle.paddingRight || '0');
+    const width = Math.floor(
+      (widthElement.getBoundingClientRect().width || widthElement.clientWidth) - horizontalPadding
+    );
+
+    return width > 0 ? width : undefined;
   }
 
   getRenderablePanels(): PanelModel[] {
@@ -418,6 +483,49 @@ export class Component extends PureComponent<Props, State> {
       return <DashboardEmpty dashboard={dashboard} canCreate={isEditable} />;
     }
 
+    const renderGrid = (gridWidth: number) => {
+      // Disable draggable if mobile device, solving an issue with unintentionally
+      // moving panels. https://github.com/grafana/grafana/issues/18497
+      const isLg = gridWidth <= config.theme2.breakpoints.values.md;
+      const draggable = isLg ? false : isLayoutEditable;
+
+      return (
+        /**
+         * The children use a width of 100%, so wrap them in an element with the
+         * calculated grid width.
+         */
+        <div style={{ width: gridWidth, height: '100%' }} ref={this.onGetWrapperDivRef}>
+          <ReactGridLayout
+            width={gridWidth}
+            isDraggable={draggable}
+            isResizable={isLayoutEditable}
+            resizeHandle={useCustomResizeHandle ? customDashboardResizeHandle : undefined}
+            resizeHandles={useCustomResizeHandle ? customDashboardResizeHandles : undefined}
+            containerPadding={[0, 0]}
+            useCSSTransforms={true}
+            margin={[GRID_CELL_VMARGIN, GRID_CELL_VMARGIN]}
+            cols={GRID_COLUMN_COUNT}
+            rowHeight={GRID_CELL_HEIGHT}
+            draggableHandle=".grid-drag-handle"
+            draggableCancel=".grid-drag-cancel"
+            layout={this.buildLayout()}
+            onDragStop={this.onDragStop}
+            onResize={this.onResize}
+            onResizeStop={this.onResizeStop}
+            onLayoutChange={this.onLayoutChange}
+          >
+            {this.renderPanels(gridWidth, draggable)}
+          </ReactGridLayout>
+        </div>
+      );
+    };
+
+    const renderEmbeddedViewPanelGrid = () => {
+      const gridWidth = this.measureEmbeddedViewPanelWidth();
+
+      return gridWidth === undefined ? null : renderGrid(gridWidth);
+    };
+
     /**
      * We have a parent with "flex: 1 1 0" we need to reset it to "flex: 1 1 auto" to have the AutoSizer
      * properly working. For more information go here:
@@ -425,49 +533,19 @@ export class Component extends PureComponent<Props, State> {
      */
     return (
       <div style={{ flex: '1 1 auto', display: this.props.editPanel ? 'none' : undefined }}>
-        <AutoSizer disableHeight>
-          {({ width }) => {
-            if (width === 0) {
-              return null;
-            }
+        {isFnDashboard && this.props.viewPanel ? (
+          renderEmbeddedViewPanelGrid()
+        ) : (
+          <AutoSizer disableHeight>
+            {({ width }) => {
+              if (width === 0) {
+                return null;
+              }
 
-            // Disable draggable if mobile device, solving an issue with unintentionally
-            // moving panels. https://github.com/grafana/grafana/issues/18497
-            const isLg = width <= config.theme2.breakpoints.values.md;
-            const draggable = isLg ? false : isLayoutEditable;
-
-            return (
-              /**
-               * The children is using a width of 100% so we need to guarantee that it is wrapped
-               * in an element that has the calculated size given by the AutoSizer. The AutoSizer
-               * has a width of 0 and will let its content overflow its div.
-               */
-              <div style={{ width: width, height: '100%' }} ref={this.onGetWrapperDivRef}>
-                <ReactGridLayout
-                  width={width}
-                  isDraggable={draggable}
-                  isResizable={isLayoutEditable}
-                  resizeHandle={useCustomResizeHandle ? customDashboardResizeHandle : undefined}
-                  resizeHandles={useCustomResizeHandle ? customDashboardResizeHandles : undefined}
-                  containerPadding={[0, 0]}
-                  useCSSTransforms={true}
-                  margin={[GRID_CELL_VMARGIN, GRID_CELL_VMARGIN]}
-                  cols={GRID_COLUMN_COUNT}
-                  rowHeight={GRID_CELL_HEIGHT}
-                  draggableHandle=".grid-drag-handle"
-                  draggableCancel=".grid-drag-cancel"
-                  layout={this.buildLayout()}
-                  onDragStop={this.onDragStop}
-                  onResize={this.onResize}
-                  onResizeStop={this.onResizeStop}
-                  onLayoutChange={this.onLayoutChange}
-                >
-                  {this.renderPanels(width, draggable)}
-                </ReactGridLayout>
-              </div>
-            );
-          }}
-        </AutoSizer>
+              return renderGrid(width);
+            }}
+          </AutoSizer>
+        )}
       </div>
     );
   }

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -22,10 +22,12 @@ import { DashboardPanel } from './DashboardPanel';
 export interface Props {
   dashboard: DashboardModel;
   isEditable: boolean;
+  isLayoutEditable?: boolean;
   editPanel: PanelModel | null;
   viewPanel: PanelModel | null;
   hidePanelMenus?: boolean;
   isFnDashboard?: boolean;
+  onLayoutUpdate?: () => void;
   portalContainerID?: string;
 }
 
@@ -33,6 +35,42 @@ interface State {
   /** Host-measured height for an embedded single-panel view. */
   viewPanelHeight?: number;
 }
+
+type GridResizeHandle = NonNullable<ReactGridLayout.ReactGridLayoutProps['resizeHandles']>[number];
+type ResizeHandleRenderer = (resizeHandle: GridResizeHandle, ref: React.RefObject<HTMLSpanElement>) => React.ReactNode;
+
+const customDashboardResizeHandles: GridResizeHandle[] = ['e', 's', 'se'];
+const customDashboardResizeHandleBaseStyle: CSSProperties = {
+  display: 'block',
+  pointerEvents: 'auto',
+  position: 'absolute',
+  touchAction: 'none',
+  visibility: 'visible',
+  zIndex: 20,
+};
+
+const customDashboardResizeHandleStyles: Record<GridResizeHandle, CSSProperties> = {
+  e: { ...customDashboardResizeHandleBaseStyle, cursor: 'ew-resize', height: '100%', right: -6, top: 0, width: 12 },
+  n: { ...customDashboardResizeHandleBaseStyle, cursor: 'ns-resize', height: 12, left: 0, top: -6, width: '100%' },
+  ne: { ...customDashboardResizeHandleBaseStyle, cursor: 'ne-resize', height: 28, right: -6, top: -6, width: 28 },
+  nw: { ...customDashboardResizeHandleBaseStyle, cursor: 'nw-resize', height: 28, left: -6, top: -6, width: 28 },
+  s: { ...customDashboardResizeHandleBaseStyle, bottom: -6, cursor: 'ns-resize', height: 12, left: 0, width: '100%' },
+  se: { ...customDashboardResizeHandleBaseStyle, bottom: -6, cursor: 'se-resize', height: 28, right: -6, width: 28 },
+  sw: { ...customDashboardResizeHandleBaseStyle, bottom: -6, cursor: 'sw-resize', height: 28, left: -6, width: 28 },
+  w: { ...customDashboardResizeHandleBaseStyle, cursor: 'ew-resize', height: '100%', left: -6, top: 0, width: 12 },
+};
+
+const renderCustomDashboardResizeHandle: ResizeHandleRenderer = (resizeHandle, ref) => (
+  <span
+    aria-hidden="true"
+    className={`react-resizable-handle react-resizable-handle-${resizeHandle}`}
+    ref={ref}
+    style={customDashboardResizeHandleStyles[resizeHandle]}
+  />
+);
+
+const customDashboardResizeHandle =
+  renderCustomDashboardResizeHandle as ReactGridLayout.ReactGridLayoutProps['resizeHandle'];
 
 export class Component extends PureComponent<Props, State> {
   private panelMap: { [key: string]: PanelModel } = {};
@@ -44,6 +82,8 @@ export class Component extends PureComponent<Props, State> {
   private lastPanelBottom = 0;
   private isLayoutInitialized = false;
   private portalResizeObserver?: ResizeObserver;
+  private gridWrapperElement?: HTMLDivElement;
+  private embeddedHeightMeasureAnimationFrame?: number;
 
   constructor(props: Props) {
     super(props);
@@ -66,6 +106,12 @@ export class Component extends PureComponent<Props, State> {
     this.eventSubs.unsubscribe();
     this.portalResizeObserver?.disconnect();
     this.portalResizeObserver = undefined;
+    if (this.embeddedHeightMeasureAnimationFrame !== undefined) {
+      if (typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(this.embeddedHeightMeasureAnimationFrame);
+      }
+      this.embeddedHeightMeasureAnimationFrame = undefined;
+    }
   }
 
   /**
@@ -94,25 +140,84 @@ export class Component extends PureComponent<Props, State> {
       return;
     }
 
-    this.portalResizeObserver = new ResizeObserver(() => {
-      const height = portalContainer.clientHeight;
-      if (height > 0 && height !== this.state.viewPanelHeight) {
-        this.setState({ viewPanelHeight: height });
-      }
-    });
+    this.portalResizeObserver = new ResizeObserver(this.scheduleEmbeddedViewPanelHeightMeasure);
     this.portalResizeObserver.observe(portalContainer);
 
-    const height = portalContainer.clientHeight;
-    if (height > 0 && height !== this.state.viewPanelHeight) {
+    const height = this.measureEmbeddedViewPanelHeight();
+    if (height !== undefined && height > 0 && height !== this.state.viewPanelHeight) {
       this.setState({ viewPanelHeight: height });
     }
+  }
+
+  scheduleEmbeddedViewPanelHeightMeasure = () => {
+    if (!this.props.isFnDashboard || !this.props.viewPanel) {
+      return;
+    }
+
+    if (this.embeddedHeightMeasureAnimationFrame !== undefined) {
+      if (typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(this.embeddedHeightMeasureAnimationFrame);
+      }
+      this.embeddedHeightMeasureAnimationFrame = undefined;
+    }
+
+    const measureHeight = () => {
+      this.embeddedHeightMeasureAnimationFrame = undefined;
+      const height = this.measureEmbeddedViewPanelHeight();
+
+      if (height !== undefined && height > 0 && height !== this.state.viewPanelHeight) {
+        this.setState({ viewPanelHeight: height });
+      }
+    };
+
+    if (typeof requestAnimationFrame !== 'function') {
+      measureHeight();
+      return;
+    }
+
+    this.embeddedHeightMeasureAnimationFrame = requestAnimationFrame(measureHeight);
+  };
+
+  measureEmbeddedViewPanelHeight(): number | undefined {
+    if (!this.props.isFnDashboard || !this.props.viewPanel || !this.props.portalContainerID) {
+      return undefined;
+    }
+
+    const portalContainer = document.getElementById(this.props.portalContainerID);
+    if (!portalContainer) {
+      return undefined;
+    }
+
+    const gridElement = this.gridWrapperElement ?? portalContainer.querySelector<HTMLElement>('.react-grid-layout');
+    if (!gridElement) {
+      const height = portalContainer.clientHeight;
+      return height > 0 ? height : undefined;
+    }
+
+    const portalRect = portalContainer.getBoundingClientRect();
+    const gridRect = gridElement.getBoundingClientRect();
+    const availableHeight = Math.floor(portalRect.bottom - gridRect.top - GRID_CELL_VMARGIN);
+
+    return availableHeight > 0 ? availableHeight : undefined;
+  }
+
+  getRenderablePanels(): PanelModel[] {
+    if (this.props.isFnDashboard && this.props.viewPanel) {
+      return [this.props.viewPanel];
+    }
+
+    return this.props.dashboard.panels;
+  }
+
+  isEmbeddedViewPanel(panel: PanelModel): boolean {
+    return Boolean(this.props.isFnDashboard && this.props.viewPanel === panel);
   }
 
   buildLayout() {
     const layout: ReactGridLayout.Layout[] = [];
     this.panelMap = {};
 
-    for (const panel of this.props.dashboard.panels) {
+    for (const panel of this.getRenderablePanels()) {
       if (!panel.key) {
         panel.key = `panel-${panel.id}-${Date.now()}`;
       }
@@ -123,11 +228,12 @@ export class Component extends PureComponent<Props, State> {
         continue;
       }
 
+      const isEmbeddedViewPanel = this.isEmbeddedViewPanel(panel);
       const panelPos: ReactGridLayout.Layout = {
         i: panel.key,
-        x: panel.gridPos.x,
-        y: panel.gridPos.y,
-        w: panel.gridPos.w,
+        x: isEmbeddedViewPanel ? 0 : panel.gridPos.x,
+        y: isEmbeddedViewPanel ? 0 : panel.gridPos.y,
+        w: isEmbeddedViewPanel ? GRID_COLUMN_COUNT : panel.gridPos.w,
         h: panel.gridPos.h,
       };
 
@@ -145,11 +251,15 @@ export class Component extends PureComponent<Props, State> {
   }
 
   onLayoutChange = (newLayout: ReactGridLayout.Layout[]) => {
+    if (this.props.isFnDashboard && this.props.viewPanel) {
+      return;
+    }
+
     for (const newPos of newLayout) {
       this.panelMap[newPos.i!].updateGridPos(newPos, this.isLayoutInitialized);
     }
 
-    if (this.isLayoutInitialized) {
+    if (!this.isLayoutInitialized) {
       this.isLayoutInitialized = true;
     }
 
@@ -172,10 +282,12 @@ export class Component extends PureComponent<Props, State> {
 
   onResizeStop: ItemCallback = (layout, oldItem, newItem) => {
     this.updateGridPos(newItem, layout);
+    this.props.onLayoutUpdate?.();
   };
 
   onDragStop: ItemCallback = (layout, oldItem, newItem) => {
     this.updateGridPos(newItem, layout);
+    this.props.onLayoutUpdate?.();
   };
 
   getPanelScreenPos(panel: PanelModel, gridWidth: number): { top: number; bottom: number } {
@@ -196,8 +308,9 @@ export class Component extends PureComponent<Props, State> {
   }
 
   getEmbeddedViewPanelHeight(): number | undefined {
-    if (!this.props.isFnDashboard || !this.props.viewPanel || !this.props.portalContainerID) {
-      return undefined;
+    const measuredHeight = this.measureEmbeddedViewPanelHeight();
+    if (measuredHeight !== undefined) {
+      return measuredHeight;
     }
 
     // Prefer the observed height; fall back to a direct read for the first paint
@@ -206,9 +319,7 @@ export class Component extends PureComponent<Props, State> {
       return this.state.viewPanelHeight;
     }
 
-    const portalContainer = document.getElementById(this.props.portalContainerID);
-    const height = portalContainer?.clientHeight ?? 0;
-    return height > 0 ? height : undefined;
+    return undefined;
   }
 
   renderPanels(gridWidth: number, isDashboardDraggable: boolean) {
@@ -226,8 +337,9 @@ export class Component extends PureComponent<Props, State> {
       this.gridWidth = gridWidth;
     }
 
-    for (const panel of this.props.dashboard.panels) {
-      const panelClasses = classNames({ 'react-grid-item--fullscreen': panel.isViewing });
+    for (const panel of this.getRenderablePanels()) {
+      const isViewing = panel.isViewing || panel === this.props.viewPanel;
+      const panelClasses = classNames({ 'react-grid-item--fullscreen': isViewing });
 
       panelElements.push(
         <GrafanaGridItem
@@ -239,7 +351,7 @@ export class Component extends PureComponent<Props, State> {
           windowHeight={this.windowHeight}
           windowWidth={this.windowWidth}
           viewPanelHeight={viewPanelHeight}
-          isViewing={panel.isViewing}
+          isViewing={isViewing}
         >
           {(width: number, height: number) => {
             return this.renderPanel(panel, width, height, isDashboardDraggable);
@@ -281,15 +393,26 @@ export class Component extends PureComponent<Props, State> {
    * This can be quite distracting and make the dashboard appear to less snappy.
    */
   onGetWrapperDivRef = (ref: HTMLDivElement | null) => {
+    if (ref) {
+      this.gridWrapperElement = ref;
+    } else {
+      this.gridWrapperElement = undefined;
+    }
+
     if (ref && contextSrv.user.authenticatedBy !== 'render') {
       setTimeout(() => {
         ref.classList.add('react-grid-layout--enable-move-animations');
       }, 50);
     }
+
+    if (ref) {
+      this.scheduleEmbeddedViewPanelHeightMeasure();
+    }
   };
 
   render() {
-    const { isEditable, dashboard, isFnDashboard } = this.props;
+    const { isEditable, isFnDashboard, isLayoutEditable = isEditable, dashboard } = this.props;
+    const useCustomResizeHandle = Boolean(isFnDashboard && isLayoutEditable);
 
     if (config.featureToggles.emptyDashboardPage && dashboard.panels.length === 0) {
       return <DashboardEmpty dashboard={dashboard} canCreate={isEditable} />;
@@ -311,7 +434,7 @@ export class Component extends PureComponent<Props, State> {
             // Disable draggable if mobile device, solving an issue with unintentionally
             // moving panels. https://github.com/grafana/grafana/issues/18497
             const isLg = width <= config.theme2.breakpoints.values.md;
-            const draggable = isLg ? false : isEditable;
+            const draggable = isLg ? false : isLayoutEditable;
 
             return (
               /**
@@ -322,8 +445,10 @@ export class Component extends PureComponent<Props, State> {
               <div style={{ width: width, height: '100%' }} ref={this.onGetWrapperDivRef}>
                 <ReactGridLayout
                   width={width}
-                  isDraggable={isFnDashboard ? false : draggable}
-                  isResizable={isFnDashboard ? false : isEditable}
+                  isDraggable={draggable}
+                  isResizable={isLayoutEditable}
+                  resizeHandle={useCustomResizeHandle ? customDashboardResizeHandle : undefined}
+                  resizeHandles={useCustomResizeHandle ? customDashboardResizeHandles : undefined}
                   containerPadding={[0, 0]}
                   useCSSTransforms={true}
                   margin={[GRID_CELL_VMARGIN, GRID_CELL_VMARGIN]}

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -26,9 +26,15 @@ export interface Props {
   viewPanel: PanelModel | null;
   hidePanelMenus?: boolean;
   isFnDashboard?: boolean;
+  portalContainerID?: string;
 }
 
-export class Component extends PureComponent<Props> {
+interface State {
+  /** Host-measured height for an embedded single-panel view. */
+  viewPanelHeight?: number;
+}
+
+export class Component extends PureComponent<Props, State> {
   private panelMap: { [key: string]: PanelModel } = {};
   private eventSubs = new Subscription();
   private windowHeight = 1200;
@@ -37,18 +43,69 @@ export class Component extends PureComponent<Props> {
   /** Used to keep track of mobile panel layout position */
   private lastPanelBottom = 0;
   private isLayoutInitialized = false;
+  private portalResizeObserver?: ResizeObserver;
 
   constructor(props: Props) {
     super(props);
+    this.state = { viewPanelHeight: undefined };
   }
 
   componentDidMount() {
     const { dashboard } = this.props;
     this.eventSubs.add(dashboard.events.subscribe(DashboardPanelsChangedEvent, this.triggerForceUpdate));
+    this.observePortalContainer();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.portalContainerID !== this.props.portalContainerID || prevProps.viewPanel !== this.props.viewPanel) {
+      this.observePortalContainer();
+    }
   }
 
   componentWillUnmount() {
     this.eventSubs.unsubscribe();
+    this.portalResizeObserver?.disconnect();
+    this.portalResizeObserver = undefined;
+  }
+
+  /**
+   * Embedded (MFE) single-panel mode only.
+   *
+   * The host sizes the portal container, but on first paint it can still measure
+   * 0 (the portal div mounts before the host flex layout resolves). A one-shot
+   * read therefore falls back to `windowHeight * 0.85`, which overflows the host
+   * box and crops the panel. Observing the container keeps the panel height in
+   * sync with whatever the host actually allocates, including window resizes.
+   */
+  observePortalContainer() {
+    this.portalResizeObserver?.disconnect();
+    this.portalResizeObserver = undefined;
+
+    const { isFnDashboard, viewPanel, portalContainerID } = this.props;
+    if (!isFnDashboard || !viewPanel || !portalContainerID) {
+      if (this.state.viewPanelHeight !== undefined) {
+        this.setState({ viewPanelHeight: undefined });
+      }
+      return;
+    }
+
+    const portalContainer = document.getElementById(portalContainerID);
+    if (!portalContainer) {
+      return;
+    }
+
+    this.portalResizeObserver = new ResizeObserver(() => {
+      const height = portalContainer.clientHeight;
+      if (height > 0 && height !== this.state.viewPanelHeight) {
+        this.setState({ viewPanelHeight: height });
+      }
+    });
+    this.portalResizeObserver.observe(portalContainer);
+
+    const height = portalContainer.clientHeight;
+    if (height > 0 && height !== this.state.viewPanelHeight) {
+      this.setState({ viewPanelHeight: height });
+    }
   }
 
   buildLayout() {
@@ -138,8 +195,25 @@ export class Component extends PureComponent<Props> {
     return { top, bottom: this.lastPanelBottom };
   }
 
+  getEmbeddedViewPanelHeight(): number | undefined {
+    if (!this.props.isFnDashboard || !this.props.viewPanel || !this.props.portalContainerID) {
+      return undefined;
+    }
+
+    // Prefer the observed height; fall back to a direct read for the first paint
+    // before the ResizeObserver has delivered its initial entry.
+    if (this.state.viewPanelHeight !== undefined) {
+      return this.state.viewPanelHeight;
+    }
+
+    const portalContainer = document.getElementById(this.props.portalContainerID);
+    const height = portalContainer?.clientHeight ?? 0;
+    return height > 0 ? height : undefined;
+  }
+
   renderPanels(gridWidth: number, isDashboardDraggable: boolean) {
     const panelElements = [];
+    const viewPanelHeight = this.getEmbeddedViewPanelHeight();
 
     // Reset last panel bottom
     this.lastPanelBottom = 0;
@@ -164,6 +238,7 @@ export class Component extends PureComponent<Props> {
           gridWidth={gridWidth}
           windowHeight={this.windowHeight}
           windowWidth={this.windowWidth}
+          viewPanelHeight={viewPanelHeight}
           isViewing={panel.isViewing}
         >
           {(width: number, height: number) => {
@@ -279,6 +354,7 @@ interface GrafanaGridItemProps extends React.HTMLAttributes<HTMLDivElement> {
   isViewing: boolean;
   windowHeight: number;
   windowWidth: number;
+  viewPanelHeight?: number;
   children: any;
 }
 
@@ -290,13 +366,15 @@ const GrafanaGridItem = React.forwardRef<HTMLDivElement, GrafanaGridItemProps>((
   let width = 100;
   let height = 100;
 
-  const { gridWidth, gridPos, isViewing, windowHeight, windowWidth, ...divProps } = props;
+  const { gridWidth, gridPos, isViewing, windowHeight, windowWidth, viewPanelHeight, ...divProps } = props;
   const style: CSSProperties = props.style ?? {};
 
   if (isViewing) {
-    // In fullscreen view mode a single panel take up full width & 85% height
+    // In fullscreen view mode a single panel take up full width & 85% height.
+    // Embedded FN dashboards have a host-owned viewport, so use that measured
+    // height instead of the browser window to avoid cropping inside the host.
     width = gridWidth!;
-    height = windowHeight * 0.85;
+    height = viewPanelHeight ?? windowHeight * 0.85;
     style.height = height;
     style.width = '100%';
   } else if (windowWidth < theme.breakpoints.values.md) {
@@ -339,6 +417,7 @@ GrafanaGridItem.displayName = 'GridItemWithDimensions';
 function mapStateToProps() {
   return (state: StoreState) => ({
     isFnDashboard: state.fnGlobalState.FNDashboard,
+    portalContainerID: state.fnGlobalState.portalContainerID,
   });
 }
 

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderTitleItems.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderTitleItems.test.tsx
@@ -5,7 +5,7 @@ import { LoadingState, TimeRange } from '@grafana/data';
 
 import { AngularNotice, PanelHeaderTitleItems } from './PanelHeaderTitleItems';
 
-function renderComponent(angularNoticeOverride?: Partial<AngularNotice>) {
+function renderComponent(angularNoticeOverride?: Partial<AngularNotice>, onEditPanel?: () => void) {
   render(
     <PanelHeaderTitleItems
       data={{
@@ -14,6 +14,7 @@ function renderComponent(angularNoticeOverride?: Partial<AngularNotice>) {
         timeRange: {} as TimeRange,
       }}
       panelId={1}
+      onEditPanel={onEditPanel}
       angularNotice={{
         ...{
           show: true,
@@ -71,5 +72,25 @@ describe('PanelHeaderTitleItems angular deprecation', () => {
         });
       });
     });
+  });
+});
+
+describe('PanelHeaderTitleItems panel edit affordance', () => {
+  const editSelector = 'fn-edit-panel';
+
+  it('does not render the edit item when the host has not opted in', () => {
+    renderComponent();
+    expect(screen.queryByTestId(editSelector)).not.toBeInTheDocument();
+  });
+
+  it('renders the edit item and reports clicks to the host', async () => {
+    const onEditPanel = jest.fn();
+    renderComponent(undefined, onEditPanel);
+
+    const editItem = screen.getByTestId(editSelector);
+    expect(editItem).toBeInTheDocument();
+
+    await userEvent.click(editItem);
+    expect(onEditPanel).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderTitleItems.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderTitleItems.tsx
@@ -143,10 +143,27 @@ const getStyles = (theme: GrafanaTheme2) => {
       color: theme.colors.warning.text,
     }),
     editPanel: css({
-      color: theme.colors.text.secondary,
       cursor: 'pointer',
-      '&:hover': {
-        color: theme.colors.text.primary,
+
+      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+        transition: theme.transitions.create(['color', 'opacity'], {
+          duration: theme.transitions.duration.short,
+        }),
+      },
+
+      '&&': {
+        color: theme.colors.text.disabled,
+        opacity: 0.72,
+      },
+
+      '&&:hover': {
+        color: theme.colors.text.secondary,
+        opacity: 0.9,
+      },
+
+      '&&:focus-visible': {
+        color: theme.colors.text.secondary,
+        opacity: 1,
       },
     }),
   };

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderTitleItems.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderTitleItems.tsx
@@ -17,14 +17,37 @@ export interface Props {
   alertState?: string;
   data: PanelData;
   panelId: number;
+  /**
+   * Set only when the embedding host has opted into panel editing. Rendering the
+   * affordance is driven entirely by this callback's presence.
+   */
+  onEditPanel?: () => void;
   onShowPanelLinks?: () => Array<LinkModel<PanelModel>>;
   panelLinks?: DataLink[];
   angularNotice?: AngularNotice;
 }
 
 export function PanelHeaderTitleItems(props: Props) {
-  const { alertState, data, panelId, onShowPanelLinks, panelLinks, angularNotice } = props;
+  const { alertState, data, panelId, onEditPanel, onShowPanelLinks, panelLinks, angularNotice } = props;
   const styles = useStyles2(getStyles);
+
+  const editItem = (
+    <Tooltip content="Edit panel">
+      <PanelChrome.TitleItem
+        className={styles.editPanel}
+        data-testid="fn-edit-panel"
+        aria-label="Edit panel"
+        onClick={(e) => {
+          // The header doubles as the drag handle, so keep the click local.
+          e.preventDefault();
+          e.stopPropagation();
+          onEditPanel?.();
+        }}
+      >
+        <Icon name="pen" size="md" />
+      </PanelChrome.TitleItem>
+    </Tooltip>
+  );
 
   // panel health
   const alertStateItem = (
@@ -72,6 +95,7 @@ export function PanelHeaderTitleItems(props: Props) {
       {timeshift}
       {alertState && alertStateItem}
       {angularNotice?.show && angularNoticeTooltip}
+      {onEditPanel && editItem}
     </>
   );
 }
@@ -117,6 +141,13 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     angularNotice: css({
       color: theme.colors.warning.text,
+    }),
+    editPanel: css({
+      color: theme.colors.text.secondary,
+      cursor: 'pointer',
+      '&:hover': {
+        color: theme.colors.text.primary,
+      },
     }),
   };
 };

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -644,6 +644,12 @@ export class PanelStateWrapperDisConnected extends PureComponent<Props, State> {
 function mapStateToProps() {
   return (state: StoreState) => ({
     isFnDashboard: state.fnGlobalState.FNDashboard,
+    /**
+     * Read from the per-dashboard store so the edit affordance follows whichever
+     * dashboard this panel belongs to.
+     */
+    enablePanelEdit: state.fnGlobalState.enablePanelEdit,
+    panelEditListener: state.fnGlobalState.metadata?.eventListener ?? undefined,
   });
 }
 

--- a/public/app/features/dashboard/utils/getPanelChromeProps.tsx
+++ b/public/app/features/dashboard/utils/getPanelChromeProps.tsx
@@ -18,6 +18,10 @@ interface CommonProps {
   plugin: PanelPlugin;
   isViewing: boolean;
   isEditing: boolean;
+  /** Host opt-in for the per-panel edit affordance. */
+  enablePanelEdit?: boolean;
+  /** Channel the host listens on for `panelEditClick`. */
+  panelEditListener?: <T>(event: { type: string; data: T }) => void;
   isInView: boolean;
   isDraggable?: boolean;
   width: number;
@@ -84,11 +88,27 @@ export function getPanelChromeProps(props: CommonProps) {
   const showAngularNotice =
     (config.featureToggles.angularDeprecationUI ?? false) && (isAngularDatasource || isAngularPanel);
 
+  /**
+   * Panel editing is host-driven: the host opts in with `enablePanelEdit` and
+   * receives the clicked panel through the same `eventListener` channel used by
+   * the stat/table/timeseries click events. Grafana renders only the trigger.
+   */
+  const panelEditListener = props.enablePanelEdit ? props.panelEditListener : undefined;
+
+  const onEditPanel = panelEditListener
+    ? () =>
+        panelEditListener({
+          type: 'panelEditClick',
+          data: { panelId: props.panel.id, title: props.panel.title ?? '' },
+        })
+    : undefined;
+
   const showTitleItems =
     (props.panel.links && props.panel.links.length > 0 && onShowPanelLinks) ||
     (props.data.series.length > 0 && props.data.series.some((v) => (v.meta?.notices?.length ?? 0) > 0)) ||
     (props.data.request && props.data.request.timeInfo) ||
     showAngularNotice ||
+    Boolean(onEditPanel) ||
     alertState;
 
   const titleItems = showTitleItems && (
@@ -96,6 +116,7 @@ export function getPanelChromeProps(props: CommonProps) {
       alertState={alertState}
       data={props.data}
       panelId={props.panel.id}
+      onEditPanel={onEditPanel}
       panelLinks={props.panel.links}
       angularNotice={{
         show: showAngularNotice,

--- a/public/app/fn-app/fn-dashboard-page/fn-dashboard.tsx
+++ b/public/app/fn-app/fn-dashboard-page/fn-dashboard.tsx
@@ -2,7 +2,7 @@ import { FC, useEffect, useMemo } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { Provider, shallowEqual, useSelector } from 'react-redux';
 
-import { FnPropMappedFromState, FnState, updatePartialFnStates } from 'app/core/reducers/fn-slice';
+import { FnPropMappedFromState, FnState, fnStateProps, updatePartialFnStates } from 'app/core/reducers/fn-slice';
 import { FnLoggerService } from 'app/fn_logger';
 import {
   MfeGlobalState,
@@ -19,6 +19,23 @@ import { RenderPortal } from '../utils';
 import { RenderFNDashboard } from './render-fn-dashboard';
 
 type FNDashboardComponentProps = Omit<FNDashboardProps, FnPropMappedFromState>;
+type RuntimeFNDashboardComponentProps = FNDashboardComponentProps & Partial<FnState>;
+
+function mergeRuntimeFnProps(props: FnState, runtimeProps: RuntimeFNDashboardComponentProps): FnState {
+  if (runtimeProps.uid !== props.uid) {
+    return props;
+  }
+
+  const runtimeRecord = runtimeProps as Record<string, unknown>;
+  const merged = { ...props } as Record<string, unknown>;
+  for (const key of fnStateProps) {
+    if (key in runtimeRecord) {
+      merged[key] = runtimeRecord[key];
+    }
+  }
+
+  return merged as FnState;
+}
 
 export const FNDashboard: FC<FNDashboardComponentProps> = (props) => {
   return (
@@ -29,6 +46,7 @@ export const FNDashboard: FC<FNDashboardComponentProps> = (props) => {
 };
 
 export const DashboardPortal: FC<FNDashboardComponentProps> = (p) => {
+  const runtimeProps = p as RuntimeFNDashboardComponentProps;
   const globalFnProps = useSelector(({ fnGlobalReducer }: MfeStore) => fnGlobalReducer, shallowEqual);
   const dashboards = useMemo(() => {
     return Object.entries(globalFnProps.dashboards)
@@ -66,8 +84,10 @@ export const DashboardPortal: FC<FNDashboardComponentProps> = (p) => {
         return null;
       }
 
+      const propsWithRuntimeUpdates = mergeRuntimeFnProps(props, runtimeProps);
+
       mfeStore.dispatch(updateRenderingDashboardUID(uid));
-      store.dispatch(updatePartialFnStates(props));
+      store.dispatch(updatePartialFnStates(propsWithRuntimeUpdates));
 
       return (
         <RenderPortal ID={props.portalContainerID} key={uid}>
@@ -75,7 +95,7 @@ export const DashboardPortal: FC<FNDashboardComponentProps> = (p) => {
             <div className="page-dashboard">
               <RenderFNDashboard
                 {...{
-                  ...props,
+                  ...propsWithRuntimeUpdates,
                   ...p,
                   uid,
                   mode: globalFnProps.mode,

--- a/public/app/fn-app/fn-dashboard-page/fn-dashboard.tsx
+++ b/public/app/fn-app/fn-dashboard-page/fn-dashboard.tsx
@@ -34,7 +34,7 @@ function mergeRuntimeFnProps(props: FnState, runtimeProps: RuntimeFNDashboardCom
     }
   }
 
-  return merged as FnState;
+  return merged as unknown as FnState;
 }
 
 export const FNDashboard: FC<FNDashboardComponentProps> = (props) => {
@@ -95,8 +95,8 @@ export const DashboardPortal: FC<FNDashboardComponentProps> = (p) => {
             <div className="page-dashboard">
               <RenderFNDashboard
                 {...{
-                  ...propsWithRuntimeUpdates,
                   ...p,
+                  ...propsWithRuntimeUpdates,
                   uid,
                   mode: globalFnProps.mode,
                 }}

--- a/public/microfrontends/fn_dashboard/index.html
+++ b/public/microfrontends/fn_dashboard/index.html
@@ -1,25 +1,6 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <title>CodeRabbit Micro-frontend</title>
-    <base href="/" />
-  </head>
-
-  <body class="theme-light app-grafana">
-    <div id="grafanaRoot"></div>
-<script nonce="">
-  window.fnData = {
+<!doctype html><html lang="en"><head><title>CodeRabbit Micro-frontend</title><base href="/"/></head><body class="theme-light app-grafana"><div id="grafanaRoot"></div><script nonce="">window.fnData = {
     themePaths: {
-      light: '../../../public/build/grafana.light.a82435e5c3d7330542d6.css',
-      dark: '../../../public/build/grafana.dark.ebf6fb75d23cfb15f9d7.css',
+      light: '../../../public/build/grafana.light.462538acd437209afd4d.css',
+      dark: '../../../public/build/grafana.dark.2dfc9020c64a2df79724.css',
     }
-  };
-</script>
-
-     
-    <script nonce="" src="../../../public/build/runtime~fn_dashboard.ac78c4490604ff4fa955.js" type="text/javascript"></script>
-      
-    <script nonce="" src="../../../public/build/fn_dashboard.55583aafee77f0fec118.js" type="text/javascript"></script>
-     
-  </body>
-</html>
+  };</script><script nonce="" src="../../../public/build/runtime.370f6d129ad5d447ccb2.js" integrity="../../../sha384-Pf2R3msP+QaFcFkfTi77UYiHFTyvElKFeNJ2M17q5g46hSdF7up91O6pyl69GZbX" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6029.5c0893d1623856e7b325.js" integrity="../../../sha384-LCMBgpyynxT2jXlhS9LdLRKvKFwONDIYBW6yP4ZgNSZo7VxpgMGsUdspsX7oCvt5" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/5234.28fd59ea0e9666a0826e.js" integrity="../../../sha384-ad5xEmu01AuQ0ldC/JRHefbRBgrPrK0uSsKUd3wduHEcxfqIS7itIqlYZHeMmXKC" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/8679.c976f48dc3678c28c752.js" integrity="../../../sha384-RIVsvwI3y5oHjcZzOdiTEGTBo4s4bLQw3Ik0bwX+hd5ELAruezQzxbNnshOgIhpA" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/2410.606a87b065106e81ad31.js" integrity="../../../sha384-BFVRm68sCi1AfvPOncSziFN0wyR9pFWDILKADQNXW3osulVTaKUFvv6PVohbLlgE" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/9569.0235c3ee1c74414043fe.js" integrity="../../../sha384-lzAsLGQMRqvXVH7fAoqEecNWFkmLZMicN5F2yBFkN39cV/CRP044RPOynQSt63rH" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6263.ed613b04757a40b68d49.js" integrity="../../../sha384-fw0P1Z6BwUn97SDsFZmGBZCc9lEvHBxpcG7UuCnidVcDfwVb8vycJISU4eKDO6zc" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6947.d1441b06d2330a97130f.js" integrity="../../../sha384-0vlIf+33/1O/0GickxH7+slIw23gFy0sUo+C4fqjYcQe1VtGP9vlMyfGcpdii6V9" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/4894.72ff78ec43d36a750815.js" integrity="../../../sha384-FLr/TeyWa1WAwzbSxtpZbNTdrZjLkLGmbfj+XiVIs1sIM972ZgmI6Q3gP1QS66v3" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/530.1c5ae442b33495c705a5.js" integrity="../../../sha384-Cv4HLe8qompnosQrBeW5214V6jyT5fWyYce0wl/H6F0e0VdI+icvpGcLUrnCqnHs" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/7223.5ef964f354c9b1de7c78.js" integrity="../../../sha384-1pV0ZXIMGLQhbarRsv+8Vtfxajy+aHA8b9PJBq7DpBcHILlSnP3T1oL13MCYKIio" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/280.a6ab45fffca94868a17c.js" integrity="../../../sha384-NzHI7e3LlfLWJ+8H/OoH9xdnZLw61xEdyssPIWVVF1rhKORJEs0tg07AErczLMmm" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/fn_dashboard.99bfd967b113e4528392.js" integrity="../../../sha384-r5Obx4eJXdYNDQxP1znnxC/XOWcu1eukIQJ3WokCYKyOCO72l9PL/F6BeWAa8Uqh" crossorigin="anonymous"></script></body></html>

--- a/public/microfrontends/fn_dashboard/index.html
+++ b/public/microfrontends/fn_dashboard/index.html
@@ -1,6 +1,25 @@
-<!doctype html><html lang="en"><head><title>CodeRabbit Micro-frontend</title><base href="/"/></head><body class="theme-light app-grafana"><div id="grafanaRoot"></div><script nonce="">window.fnData = {
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>CodeRabbit Micro-frontend</title>
+    <base href="/" />
+  </head>
+
+  <body class="theme-light app-grafana">
+    <div id="grafanaRoot"></div>
+<script nonce="">
+  window.fnData = {
     themePaths: {
-      light: '../../../public/build/grafana.light.462538acd437209afd4d.css',
-      dark: '../../../public/build/grafana.dark.2dfc9020c64a2df79724.css',
+      light: '../../../public/build/grafana.light.a82435e5c3d7330542d6.css',
+      dark: '../../../public/build/grafana.dark.ebf6fb75d23cfb15f9d7.css',
     }
-  };</script><script nonce="" src="../../../public/build/runtime.370f6d129ad5d447ccb2.js" integrity="../../../sha384-Pf2R3msP+QaFcFkfTi77UYiHFTyvElKFeNJ2M17q5g46hSdF7up91O6pyl69GZbX" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6029.5c0893d1623856e7b325.js" integrity="../../../sha384-LCMBgpyynxT2jXlhS9LdLRKvKFwONDIYBW6yP4ZgNSZo7VxpgMGsUdspsX7oCvt5" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/5234.28fd59ea0e9666a0826e.js" integrity="../../../sha384-ad5xEmu01AuQ0ldC/JRHefbRBgrPrK0uSsKUd3wduHEcxfqIS7itIqlYZHeMmXKC" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/8679.c976f48dc3678c28c752.js" integrity="../../../sha384-RIVsvwI3y5oHjcZzOdiTEGTBo4s4bLQw3Ik0bwX+hd5ELAruezQzxbNnshOgIhpA" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/2410.606a87b065106e81ad31.js" integrity="../../../sha384-BFVRm68sCi1AfvPOncSziFN0wyR9pFWDILKADQNXW3osulVTaKUFvv6PVohbLlgE" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/9569.0235c3ee1c74414043fe.js" integrity="../../../sha384-lzAsLGQMRqvXVH7fAoqEecNWFkmLZMicN5F2yBFkN39cV/CRP044RPOynQSt63rH" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6263.ed613b04757a40b68d49.js" integrity="../../../sha384-fw0P1Z6BwUn97SDsFZmGBZCc9lEvHBxpcG7UuCnidVcDfwVb8vycJISU4eKDO6zc" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6947.d1441b06d2330a97130f.js" integrity="../../../sha384-0vlIf+33/1O/0GickxH7+slIw23gFy0sUo+C4fqjYcQe1VtGP9vlMyfGcpdii6V9" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/4894.72ff78ec43d36a750815.js" integrity="../../../sha384-FLr/TeyWa1WAwzbSxtpZbNTdrZjLkLGmbfj+XiVIs1sIM972ZgmI6Q3gP1QS66v3" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/530.1c5ae442b33495c705a5.js" integrity="../../../sha384-Cv4HLe8qompnosQrBeW5214V6jyT5fWyYce0wl/H6F0e0VdI+icvpGcLUrnCqnHs" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/7223.5ef964f354c9b1de7c78.js" integrity="../../../sha384-1pV0ZXIMGLQhbarRsv+8Vtfxajy+aHA8b9PJBq7DpBcHILlSnP3T1oL13MCYKIio" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/280.a6ab45fffca94868a17c.js" integrity="../../../sha384-NzHI7e3LlfLWJ+8H/OoH9xdnZLw61xEdyssPIWVVF1rhKORJEs0tg07AErczLMmm" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/fn_dashboard.99bfd967b113e4528392.js" integrity="../../../sha384-r5Obx4eJXdYNDQxP1znnxC/XOWcu1eukIQJ3WokCYKyOCO72l9PL/F6BeWAa8Uqh" crossorigin="anonymous"></script></body></html>
+  };
+</script>
+
+
+    <script nonce="" src="../../../public/build/runtime~fn_dashboard.ac78c4490604ff4fa955.js" type="text/javascript"></script>
+
+    <script nonce="" src="../../../public/build/fn_dashboard.65ea0ad2b88d91240146.js" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/public/microfrontends/fn_dashboard/index.html
+++ b/public/microfrontends/fn_dashboard/index.html
@@ -1,25 +1,6 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <title>CodeRabbit Micro-frontend</title>
-    <base href="/" />
-  </head>
-
-  <body class="theme-light app-grafana">
-    <div id="grafanaRoot"></div>
-<script nonce="">
-  window.fnData = {
+<!doctype html><html lang="en"><head><title>CodeRabbit Micro-frontend</title><base href="/"/></head><body class="theme-light app-grafana"><div id="grafanaRoot"></div><script nonce="">window.fnData = {
     themePaths: {
-      light: '../../../public/build/grafana.light.a82435e5c3d7330542d6.css',
-      dark: '../../../public/build/grafana.dark.ebf6fb75d23cfb15f9d7.css',
+      light: '../../../public/build/grafana.light.462538acd437209afd4d.css',
+      dark: '../../../public/build/grafana.dark.2dfc9020c64a2df79724.css',
     }
-  };
-</script>
-
-
-    <script nonce="" src="../../../public/build/runtime~fn_dashboard.ac78c4490604ff4fa955.js" type="text/javascript"></script>
-
-    <script nonce="" src="../../../public/build/fn_dashboard.65ea0ad2b88d91240146.js" type="text/javascript"></script>
-
-  </body>
-</html>
+  };</script><script nonce="" src="../../../public/build/runtime.06053f7b9be7b3a302b4.js" integrity="../../../sha384-FfG0DryIOTlg3ZgHMQtCXrHWQZxwgpAsfCKIPRmIpSwTpMrXiA/HZy0LVBUDuqy5" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6029.5c0893d1623856e7b325.js" integrity="../../../sha384-LCMBgpyynxT2jXlhS9LdLRKvKFwONDIYBW6yP4ZgNSZo7VxpgMGsUdspsX7oCvt5" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/5234.28fd59ea0e9666a0826e.js" integrity="../../../sha384-ad5xEmu01AuQ0ldC/JRHefbRBgrPrK0uSsKUd3wduHEcxfqIS7itIqlYZHeMmXKC" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/8679.c976f48dc3678c28c752.js" integrity="../../../sha384-RIVsvwI3y5oHjcZzOdiTEGTBo4s4bLQw3Ik0bwX+hd5ELAruezQzxbNnshOgIhpA" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/2410.606a87b065106e81ad31.js" integrity="../../../sha384-BFVRm68sCi1AfvPOncSziFN0wyR9pFWDILKADQNXW3osulVTaKUFvv6PVohbLlgE" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/9569.4b5f383be467c7916ce9.js" integrity="../../../sha384-eqLyjEeB6RWehUI8QrmJdtxcedjWzaP8X7B+T6KQMDLe5oImzuCnsuhXqqCkCMBR" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6263.697b4a5efb88b11efa86.js" integrity="../../../sha384-w3zpaDNkqnTA00Yb7jkOuC7QKpkkk0JEtjli7vRJNRXQuCyzI6xlXn+pQz0W/5mm" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6947.d1441b06d2330a97130f.js" integrity="../../../sha384-0vlIf+33/1O/0GickxH7+slIw23gFy0sUo+C4fqjYcQe1VtGP9vlMyfGcpdii6V9" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/2494.c87dd5f28eaad6c4f65f.js" integrity="../../../sha384-2X+Ib0kRIWaJwHht0sIEqI3Ug/vIHeV2fqhS+IRXF+3YWTbsUTiJJbv2kOoTvZUV" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/530.1c5ae442b33495c705a5.js" integrity="../../../sha384-Cv4HLe8qompnosQrBeW5214V6jyT5fWyYce0wl/H6F0e0VdI+icvpGcLUrnCqnHs" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/7223.1f96ac8f558fea8ae1f2.js" integrity="../../../sha384-/iEQH2iKfbjEgdpxMvUkmZ3C8+Ywgxh6ALgTmaIIWL0K+W4GY1Aj6/N1k/DJI9VA" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/280.45658a454830320f1b8c.js" integrity="../../../sha384-sKOuRlFNRQ3DlQeuR+QAH4IrOuXntWqlTwLRBGU8Eyoi9QXLLEXKlY6GWdKGxKgy" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/fn_dashboard.1892a9348f1436b15fa5.js" integrity="../../../sha384-hda3YVz9uHlSlNKo5YDb8rjyFeYr3ijGj8BJNZoZX/qpGj5eMt/QShL2nj9lJYpJ" crossorigin="anonymous"></script></body></html>

--- a/public/microfrontends/fn_dashboard/index.html
+++ b/public/microfrontends/fn_dashboard/index.html
@@ -10,16 +10,16 @@
 <script nonce="">
   window.fnData = {
     themePaths: {
-      light: '../../../public/build/grafana.light.c51ef085b5acae48f0ae.css',
-      dark: '../../../public/build/grafana.dark.de1c85c981de3f7c20f0.css',
+      light: '../../../public/build/grafana.light.a82435e5c3d7330542d6.css',
+      dark: '../../../public/build/grafana.dark.ebf6fb75d23cfb15f9d7.css',
     }
   };
 </script>
 
      
-    <script nonce="" src="../../../public/build/runtime~fn_dashboard.bf82cca0bdd91aab521f.js" type="text/javascript"></script>
+    <script nonce="" src="../../../public/build/runtime~fn_dashboard.ac78c4490604ff4fa955.js" type="text/javascript"></script>
       
-    <script nonce="" src="../../../public/build/fn_dashboard.1bbf49e9b9bbd3087187.js" type="text/javascript"></script>
+    <script nonce="" src="../../../public/build/fn_dashboard.55583aafee77f0fec118.js" type="text/javascript"></script>
      
   </body>
 </html>

--- a/public/microfrontends/fn_dashboard/index.html
+++ b/public/microfrontends/fn_dashboard/index.html
@@ -1,6 +1,25 @@
-<!doctype html><html lang="en"><head><title>CodeRabbit Micro-frontend</title><base href="/"/></head><body class="theme-light app-grafana"><div id="grafanaRoot"></div><script nonce="">window.fnData = {
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>CodeRabbit Micro-frontend</title>
+    <base href="/" />
+  </head>
+
+  <body class="theme-light app-grafana">
+    <div id="grafanaRoot"></div>
+<script nonce="">
+  window.fnData = {
     themePaths: {
-      light: '../../../public/build/grafana.light.b7b9f5ec72b47763c5e8.css',
-      dark: '../../../public/build/grafana.dark.7abd487b4416c98e54db.css',
+      light: '../../../public/build/grafana.light.c51ef085b5acae48f0ae.css',
+      dark: '../../../public/build/grafana.dark.de1c85c981de3f7c20f0.css',
     }
-  };</script><script nonce="" src="../../../public/build/runtime.394fb2248dd119f0f627.js" integrity="../../../sha384-pDEhDAIVRd+cBT15Zs+PO6oPBwrejPBgmIxRQ5Xhq/iWrvnqJT2PWbf2cCHE8p7b" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6029.5c0893d1623856e7b325.js" integrity="../../../sha384-LCMBgpyynxT2jXlhS9LdLRKvKFwONDIYBW6yP4ZgNSZo7VxpgMGsUdspsX7oCvt5" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/5234.b70fab3b1fc48a116b38.js" integrity="../../../sha384-6z/x7G0Kuq5vHq8SixVqItA9g2cqD1Tw4nVd8f947akcoV/Y/8suL1cymdz83GDW" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/7327.f19f24caa72cbd70fc78.js" integrity="../../../sha384-eKrZIWVcSGS25mg+sRrLJZ6CbPsD0juod1HcOhkPrEogphOQHa1+ELosmS4ZLYfK" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/2410.606a87b065106e81ad31.js" integrity="../../../sha384-BFVRm68sCi1AfvPOncSziFN0wyR9pFWDILKADQNXW3osulVTaKUFvv6PVohbLlgE" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/9569.e1791108871bcaba32d4.js" integrity="../../../sha384-EkDJdU9jqQRLpdWqUaFEgjobHD4gPNl+Qq71bl61vu1+6LXJK7COZxcjfw4jOX/v" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6263.c2ee3ac2fe2934607fe0.js" integrity="../../../sha384-2VdfTyu5FomdOEQn4OvRVDRX1C8TWJAVA9tPJlRoPq0FvWM+KhrzCtq6HNg2m9Fe" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/6947.6fa9ff70b916365b6259.js" integrity="../../../sha384-IbuK21HpudeblOqkfNJfp6wvrHVlhxcd2s830P75awAlEiCS5pLngZ18qg0S0K/W" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/4894.89be4a92855ef9eb683b.js" integrity="../../../sha384-EoWaAzRvJN8kNdv/uj04uulL4FoocvQgg0+KIIlTi+FoNCAZHcxAj/pJ57FZi3qK" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/530.1c5ae442b33495c705a5.js" integrity="../../../sha384-Cv4HLe8qompnosQrBeW5214V6jyT5fWyYce0wl/H6F0e0VdI+icvpGcLUrnCqnHs" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/7223.3469e946aa387b58eee6.js" integrity="../../../sha384-gZQ1DcmqlgMitFN+ZbVz+RySUpIsi7pWkG7PbWdOMxJwmpt0q6eSSdwuRNGZQfC3" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/280.a6ab45fffca94868a17c.js" integrity="../../../sha384-NzHI7e3LlfLWJ+8H/OoH9xdnZLw61xEdyssPIWVVF1rhKORJEs0tg07AErczLMmm" crossorigin="anonymous"></script><script nonce="" src="../../../public/build/fn_dashboard.cfe094c7791801cd5c96.js" integrity="../../../sha384-jecRwVMbnskCGUItxV8nGSBpKZ4V7vpZ0Cku7qyQDaTd9UEr5uuvliLgeJPyJqPE" crossorigin="anonymous"></script></body></html>
+  };
+</script>
+
+     
+    <script nonce="" src="../../../public/build/runtime~fn_dashboard.bf82cca0bdd91aab521f.js" type="text/javascript"></script>
+      
+    <script nonce="" src="../../../public/build/fn_dashboard.1bbf49e9b9bbd3087187.js" type="text/javascript"></script>
+     
+  </body>
+</html>

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -238,7 +238,7 @@ $dropdownBackground: #1a181d;
 $dropdownBorder: #322f37;
 $dropdownDividerTop: #322f37;
 $dropdownDividerBottom: #322f37;
-$dropdownShadow: 0px 8px 24px rgba(18, 16, 20, 0.9);
+$dropdownShadow: 0px 4px 8px rgba(0, 0, 0, 0.4), 0px 16px 32px rgba(0, 0, 0, 0.5);
 
 $dropdownLinkColor: $link-color;
 $dropdownLinkColorHover: $white;
@@ -268,7 +268,7 @@ $side-menu-header-color: #efedf0;
 // -------------------------
 $menu-dropdown-bg: #1a181d;
 $menu-dropdown-hover-bg: rgba(255, 255, 255, 0.06);
-$menu-dropdown-shadow: 0px 8px 24px rgba(18, 16, 20, 0.9);
+$menu-dropdown-shadow: 0px 4px 8px rgba(0, 0, 0, 0.4), 0px 16px 32px rgba(0, 0, 0, 0.5);
 
 // Tabs
 // -------------------------
@@ -296,13 +296,13 @@ $tooltipBackground: #232127;
 $tooltipColor: #efedf0;
 $tooltipArrowColor: #232127;
 $tooltipBackgroundError: #dc3b5d;
-$tooltipShadow: 0px 4px 8px rgba(18, 16, 20, 0.75);
+$tooltipShadow: 0px 2px 4px rgba(0, 0, 0, 0.35), 0px 8px 16px rgba(0, 0, 0, 0.4);
 
 $popover-bg: #1a181d;
 $popover-color: #efedf0;
 $popover-border-color: #322f37;
 $popover-header-bg: #232127;
-$popover-shadow: 0px 8px 24px rgba(18, 16, 20, 0.9);
+$popover-shadow: 0px 4px 8px rgba(0, 0, 0, 0.4), 0px 16px 32px rgba(0, 0, 0, 0.5);
 
 $popover-help-bg: $tooltipBackground;
 $popover-help-color: $text-color;

--- a/public/sass/_variables.generated.scss
+++ b/public/sass/_variables.generated.scss
@@ -114,8 +114,8 @@ $font-size-xs: 10px !default;
 
 $line-height-base: 1.5714285714285714 !default;
 
-$font-weight-regular: 300 !default;
-$font-weight-semi-bold: 400 !default;
+$font-weight-regular: 400 !default;
+$font-weight-semi-bold: 500 !default;
 
 $font-size-h1: 1.75rem !default;
 $font-size-h2: 1.5rem !default;
@@ -177,7 +177,7 @@ $zindex-typeahead: 1030;
 $btn-padding-x: 14px !default;
 $btn-padding-y: 0 !default;
 $btn-line-height: $line-height-base;
-$btn-font-weight: 400 !default;
+$btn-font-weight: 500 !default;
 
 $btn-padding-x-sm: 7px !default;
 $btn-padding-y-sm: 4px !default;
@@ -196,8 +196,8 @@ $navbar-padding: 20px;
 
 // dashboard
 $dashboard-padding: $space-md;
-$panel-padding: 8px;
-$panel-header-height: 32px;
+$panel-padding: 12px;
+$panel-header-height: 40px;
 $panel-header-z-index: 10;
 
 // tabs

--- a/public/sass/_variables.light.generated.scss
+++ b/public/sass/_variables.light.generated.scss
@@ -57,13 +57,13 @@ $gray-7: #fbfbfb;
 
 $white: #ffffff;
 
-$layer0: #e9e7ed;
-$layer1: #faf8fb;
-$layer2: #fdfdfe;
+$layer0: #f5f3f7;
+$layer1: #ffffff;
+$layer2: #faf9fb;
 
-$divider: #e3e0e7;
-$border0: #e3e0e7;
-$border1: #d0ccd5;
+$divider: #ebe9ee;
+$border0: #ebe9ee;
+$border1: #dcd9e1;
 
 // Accent colors
 // -------------------------
@@ -93,9 +93,9 @@ $critical: #ca244d;
 
 // Scaffolding
 // -------------------------
-$body-bg: #e9e7ed;
-$page-bg: #e9e7ed;
-$dashboard-bg: #e9e7ed;
+$body-bg: #f5f3f7;
+$page-bg: #f5f3f7;
+$dashboard-bg: #f5f3f7;
 
 $text-color: #211f24;
 $text-color-strong: #000000;
@@ -128,30 +128,30 @@ $hr-border-color: $gray-4 !default;
 
 // Panel
 // -------------------------
-$panel-bg: #faf8fb;
-$panel-border: 1px solid #e3e0e7;
+$panel-bg: #ffffff;
+$panel-border: 1px solid #ebe9ee;
 $panel-header-hover-bg: rgba(0, 0, 0, 0.06);
 $panel-box-shadow: none;
 $panel-corner: $panel-bg;
 
 // Page header
-$page-header-bg: #e9e7ed;
+$page-header-bg: #f5f3f7;
 $page-header-shadow: inset 0px -3px 10px $gray-6;
-$page-header-border-color: #e9e7ed;
+$page-header-border-color: #f5f3f7;
 
 $divider-border-color: $gray-2;
 
 // Graphite Target Editor
-$tight-form-func-bg: #fdfdfe;
-$tight-form-func-highlight-bg: #f6f6fb;
+$tight-form-func-bg: #faf9fb;
+$tight-form-func-highlight-bg: #f5f3f7;
 
-$modal-backdrop-bg: #faf8fb;
+$modal-backdrop-bg: #ffffff;
 $code-tag-bg: $gray-6;
 $code-tag-border: $gray-4;
 
 // cards
-$card-background: #fdfdfe;
-$card-background-hover: #fdfdfe;
+$card-background: #faf9fb;
+$card-background-hover: #faf9fb;
 $card-shadow: none;
 
 // Lists
@@ -168,10 +168,10 @@ $scrollbarBorder: $gray-7;
 
 // Tables
 // -------------------------
-$table-bg-accent: #fdfdfe;
-$table-border: #d0ccd5;
-$table-bg-odd: rgb(245, 243, 245);
-$table-bg-hover: rgb(237, 235, 238);
+$table-bg-accent: #faf9fb;
+$table-border: #dcd9e1;
+$table-bg-odd: rgb(249, 249, 249);
+$table-bg-hover: rgb(242, 242, 242);
 
 // Buttons
 // -------------------------
@@ -207,16 +207,16 @@ $btn-active-box-shadow: 0px 0px 4px rgba(234, 161, 51, 0.6);
 
 // Forms
 // -------------------------
-$input-bg: #faf8fb;
+$input-bg: #ffffff;
 $input-bg-disabled: rgba(45, 51, 62, 0.04);
 
 $input-color: #211f24;
-$input-border-color: #d0ccd5;
+$input-border-color: #dcd9e1;
 $input-box-shadow: none;
 $input-border-focus: #5794f2;
 $input-box-shadow-focus: #5794f2;
 $input-color-placeholder: #8e8a94;
-$input-label-bg: #fdfdfe;
+$input-label-bg: #faf9fb;
 $input-color-select-arrow: #7b8087;
 
 // search
@@ -229,11 +229,11 @@ $typeahead-selected-color: $yellow;
 
 // Dropdowns
 // -------------------------
-$dropdownBackground: #faf8fb;
-$dropdownBorder: #e3e0e7;
-$dropdownDividerTop: #e3e0e7;
-$dropdownDividerBottom: #e3e0e7;
-$dropdownShadow: 0px 13px 20px 1px rgba(33, 31, 36, 0.12);
+$dropdownBackground: #ffffff;
+$dropdownBorder: #ebe9ee;
+$dropdownDividerTop: #ebe9ee;
+$dropdownDividerBottom: #ebe9ee;
+$dropdownShadow: 0px 2px 4px rgba(33, 31, 36, 0.06), 0px 12px 32px rgba(33, 31, 36, 0.12);
 
 $dropdownLinkColor: $dark-2;
 $dropdownLinkColorHover: $link-color;
@@ -263,9 +263,9 @@ $side-menu-header-color: #e9edf2;
 
 // Menu dropdowns
 // -------------------------
-$menu-dropdown-bg: #faf8fb;
+$menu-dropdown-bg: #ffffff;
 $menu-dropdown-hover-bg: rgba(0, 0, 0, 0.06);
-$menu-dropdown-shadow: 0px 13px 20px 1px rgba(33, 31, 36, 0.12);
+$menu-dropdown-shadow: 0px 2px 4px rgba(33, 31, 36, 0.06), 0px 12px 32px rgba(33, 31, 36, 0.12);
 
 // Tabs
 // -------------------------
@@ -283,17 +283,17 @@ $alert-warning-bg: #ffc53d;
 $alert-info-bg: #ffc53d;
 
 // Tooltips and popovers
-$tooltipBackground: #fdfdfe;
+$tooltipBackground: #faf9fb;
 $tooltipColor: #211f24;
-$tooltipArrowColor: #fdfdfe;
+$tooltipArrowColor: #faf9fb;
 $tooltipBackgroundError: #dc3b5d;
-$tooltipShadow: 0px 4px 8px rgba(33, 31, 36, 0.15);
+$tooltipShadow: 0px 1px 2px rgba(33, 31, 36, 0.06), 0px 4px 12px rgba(33, 31, 36, 0.08);
 
-$popover-bg: #faf8fb;
+$popover-bg: #ffffff;
 $popover-color: #211f24;
-$popover-border-color: #e3e0e7;
-$popover-header-bg: #fdfdfe;
-$popover-shadow: 0px 13px 20px 1px rgba(33, 31, 36, 0.12);
+$popover-border-color: #ebe9ee;
+$popover-header-bg: #faf9fb;
+$popover-shadow: 0px 2px 4px rgba(33, 31, 36, 0.06), 0px 12px 32px rgba(33, 31, 36, 0.12);
 
 $graph-tooltip-bg: $gray-5;
 
@@ -305,7 +305,7 @@ $popover-error-bg: $btn-danger-bg;
 $popover-help-bg: $tooltipBackground;
 $popover-help-color: $tooltipColor;
 
-$popover-code-bg: #faf8fb;
+$popover-code-bg: #ffffff;
 $popover-code-boxshadow: 0 0 5px $gray60;
 
 // images
@@ -338,9 +338,9 @@ $diff-label-bg: rgba(0, 0, 0, 0.06);
 $diff-label-fg: $gray-2;
 
 $diff-arrow-color: $dark-2;
-$diff-group-bg: #fdfdfe;
+$diff-group-bg: #faf9fb;
 
-$diff-json-bg: #fdfdfe;
+$diff-json-bg: #faf9fb;
 $diff-json-fg: #211f24;
 
 $diff-json-added: $blue-shade;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4068,6 +4068,7 @@ __metadata:
     "@grafana/schema": "npm:11.3.0-pre"
     "@grafana/tsconfig": "npm:^2.0.0"
     "@hello-pangea/dnd": "npm:16.6.0"
+    "@heroicons/react": "npm:2.2.0"
     "@leeoniya/ufuzzy": "npm:1.0.14"
     "@monaco-editor/react": "npm:4.6.0"
     "@popperjs/core": "npm:2.11.8"
@@ -4225,6 +4226,15 @@ __metadata:
     react: ^16.8.5 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.5 || ^17.0.0 || ^18.0.0
   checksum: 10/f377461d400c8223174745e4d7ecf4fb0146f9e807413f98120ebbcf075282e631273988d336daaf1fb8e6b6c6a1a8e4f99beefecd7a6b68ccc3bb064d38f13f
+  languageName: node
+  linkType: hard
+
+"@heroicons/react@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@heroicons/react@npm:2.2.0"
+  peerDependencies:
+    react: ">= 16 || ^19.0.0-rc"
+  checksum: 10/5bf8a3faa16f1566165bfaec2448ce3c2bd3e4f49e446ccf233f6aa63626155585eaf7e89f01fb4e8e92dfca3d7113b8c517c3b3c04036b9243c818595db3908
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

A reporting-backed custom dashboard panel failed to render:

```
error: [Grafana proxy]:: Failed to resolve FN-redacted query {
  dashboardUID: 'cd-7e2676fddaf74e218328',
  queryCount: 1,
  queries: [ { refId: 'A', datasourceUid: 'mfe-bigquery-prod',
               rawSqlPrefix: '[MFE_REDACTED:p:4:A]' } ]
}
```

## Root cause

`maskRawQueryFields` masked **any** query field whose value was a string — including the empty string:

```go
if _, err := cur.String(); err == nil {
    obj.Set(field, mask)   // "" -> "[MFE_REDACTED:p:4:A]"
}
```

Verified against `simplejson`: `CheckGet("rawSql")` on `""` returns `ok=true` and `String()` returns `("", nil)`, so an empty value took the mask branch.

For a panel that intentionally carries no SQL, that **fabricates a marker promising the proxy a query which does not exist**. The proxy's contract is to fail closed on any value carrying the redaction prefix — it must parse a valid key rather than forward a literal placeholder upstream. So it resolves panel 4, finds `rawSql: ""`, hits `if (!originalSql) return null`, and rejects the entire `/api/ds/query` batch.

## Fix

Skip masking when the query field is empty or whitespace-only. Safe by construction: there is no query text to leak, and the marker exists solely to stand in for text that was removed.

Two shapes depend on an intentionally empty query field:

- **CodeRabbit reporting-backed panels** — data comes from the reporting API via a `crReportingTag` on the target rather than from SQL.
- **Variable metricFindQueries** — these already arrive with an empty `rawSql` and a `tempVar<N>` refId. The proxy has a *dedicated pass-through* for exactly this shape (`if (raw.length === 0)`), which the fabricated marker was routing around. So this also removes a latent inconsistency that predates the reporting work.

### Why not gate on "is this a custom dashboard?"

The requested framing was to skip tag generation for custom dashboards specifically, but that isn't the right seam:

1. **The fork has no notion of a custom dashboard.** `pkg/api` has no `cd-` prefix or dashboard-kind concept; introducing one would mean threading a classification through the mask path purely to express "this panel has no SQL" — which the panel already states by having no SQL.
2. **Custom dashboards still contain SQL panels.** A generated dashboard is typically *mixed*. Disabling masking per-dashboard would unmask real SQL on the SQL-backed panels — a regression of the property the mask exists to guarantee.
3. **An empty query is meaningless to mask on any dashboard.** The condition is a property of the value, not of the dashboard.

The narrower predicate fixes the reported failure, keeps every non-empty query masked, and adds no new coupling.

## Verification

| Check | Result |
|---|---|
| `go build ./pkg/api/` | clean |
| `go test ./pkg/api/ -run "TestMask\|TestIsCodeRabbitMFE\|TestMfe\|TestPanelAndVariable"` | **ok** |
| `gofmt -l` | clean |

Three regression tests added:
- empty `rawSql` is left untouched, and a sibling `crReportingTag` survives intact
- whitespace-only query is left untouched
- a mixed dashboard still masks the non-empty query on another panel -> `[MFE_REDACTED:p:5:A]`

I confirmed the tests actually catch the bug: with the guard removed all three fail with `actual: "[MFE_REDACTED:p:4:A]"`; with it restored all pass.

**Pre-existing failure, unrelated:** `TestDashboardSnapshotAPIEndpoint_singleSnapshot` panics with `no guardian factory implementation provided`. I confirmed it fails identically on a stashed/clean tree.

## Related

Pairs with mono#25309, which generates these reporting-backed panels. Both are needed for a reporting panel to render.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty or whitespace-only dashboard query fields are now preserved instead of being redacted.
  - Non-empty query fields continue to be masked as expected.
  - Reporting metadata remains unchanged during masking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->