### PR TITLE
fix panel loading bar alignment

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -4,7 +4,7 @@ import { useToggle } from 'react-use';
 import { LoadingState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
-import { getPanelLoadingBarStyles, PanelChrome, PanelChromeProps } from './PanelChrome';
+import { PanelChrome, PanelChromeProps } from './PanelChrome';
 
 const setup = (propOverrides?: Partial<PanelChromeProps>) => {
   const props: PanelChromeProps = {
@@ -140,10 +140,13 @@ it.each<[string, Partial<PanelChromeProps>]>([
 it('aligns the loading indicator with the flat part of the rounded panel border', () => {
   setup({ loadingState: LoadingState.Loading });
 
-  expect(screen.getByLabelText('Panel loading bar')).toBeInTheDocument();
-  expect(getPanelLoadingBarStyles('12px', 1)).toEqual({
+  const loadingBar = screen.getByLabelText('Panel loading bar');
+  const loadingBarContainer = loadingBar.parentElement?.parentElement;
+
+  expect(loadingBarContainer).toBeInTheDocument();
+  expect(getComputedStyle(loadingBarContainer!)).toMatchObject({
     position: 'absolute',
-    top: -1,
+    top: '-1px',
     left: 'calc(12px - 1px)',
     right: 'calc(12px - 1px)',
     pointerEvents: 'none',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -4,7 +4,7 @@ import { useToggle } from 'react-use';
 import { LoadingState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
-import { PanelChrome, PanelChromeProps } from './PanelChrome';
+import { getPanelLoadingBarStyles, PanelChrome, PanelChromeProps } from './PanelChrome';
 
 const setup = (propOverrides?: Partial<PanelChromeProps>) => {
   const props: PanelChromeProps = {
@@ -123,22 +123,31 @@ it('does not render error status in the panel header if loadingState is error, b
   expect(screen.queryByTestId('panel-status')).not.toBeInTheDocument();
 });
 
-it('renders loading indicator in the panel header if loadingState is loading', () => {
+it.each<[string, Partial<PanelChromeProps>]>([
+  ['default panel', {}],
+  ['panel with a fixed header', { hoverHeader: false }],
+  ['panel with a hover header', { hoverHeader: true }],
+  ['transparent panel', { displayMode: 'transparent' }],
+  ['collapsed panel', { collapsible: true, collapsed: true }],
+  ['mobile-width panel', { width: 320, height: 100 }],
+  ['narrow grid panel', { width: 24, height: 100 }],
+])('renders the loading indicator for a %s', (_name, propOverrides) => {
+  setup({ ...propOverrides, loadingState: LoadingState.Loading });
+
+  expect(screen.getByLabelText('Panel loading bar')).toBeInTheDocument();
+});
+
+it('aligns the loading indicator with the flat part of the rounded panel border', () => {
   setup({ loadingState: LoadingState.Loading });
 
   expect(screen.getByLabelText('Panel loading bar')).toBeInTheDocument();
-});
-
-it('renders loading indicator in the panel header if loadingState is loading regardless of not having a header', () => {
-  setup({ loadingState: LoadingState.Loading, hoverHeader: true });
-
-  expect(screen.getByLabelText('Panel loading bar')).toBeInTheDocument();
-});
-
-it('renders loading indicator in the panel header if loadingState is loading regardless of having a header', () => {
-  setup({ loadingState: LoadingState.Loading, hoverHeader: false });
-
-  expect(screen.getByLabelText('Panel loading bar')).toBeInTheDocument();
+  expect(getPanelLoadingBarStyles('12px', 1)).toEqual({
+    position: 'absolute',
+    top: -1,
+    left: 'calc(12px - 1px)',
+    right: 'calc(12px - 1px)',
+    pointerEvents: 'none',
+  });
 });
 
 it('renders streaming indicator in the panel header if loadingState is streaming', () => {

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -104,8 +104,7 @@ interface HoverHeader {
  */
 export type PanelPadding = 'none' | 'md';
 
-/** @internal Exported only so the geometry remains independently testable. */
-export function getPanelLoadingBarStyles(panelBorderRadius: string, panelBorderWidth: number) {
+function getPanelLoadingBarStyles(panelBorderRadius: string, panelBorderWidth: number) {
   const inset = `calc(${panelBorderRadius} - ${panelBorderWidth}px)`;
 
   return {

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -104,6 +104,19 @@ interface HoverHeader {
  */
 export type PanelPadding = 'none' | 'md';
 
+/** @internal Exported only so the geometry remains independently testable. */
+export function getPanelLoadingBarStyles(panelBorderRadius: string, panelBorderWidth: number) {
+  const inset = `calc(${panelBorderRadius} - ${panelBorderWidth}px)`;
+
+  return {
+    position: 'absolute' as const,
+    top: -panelBorderWidth,
+    left: inset,
+    right: inset,
+    pointerEvents: 'none' as const,
+  };
+}
+
 /**
  * @internal
  */
@@ -383,6 +396,8 @@ const getContentStyle = (
 
 const getStyles = (isFNPanel?: boolean) => (theme: GrafanaTheme2) => {
   const { background, borderColor, padding } = theme.components.panel;
+  const panelBorderWidth = 1;
+  const panelBorderRadius = theme.shape.borderRadius(3);
   const focusStyles = getFocusStyles(theme);
   const elevatedFocusShadow = `${focusStyles.boxShadow}, ${theme.shadows.z2}`;
 
@@ -390,9 +405,9 @@ const getStyles = (isFNPanel?: boolean) => (theme: GrafanaTheme2) => {
     container: css({
       label: 'panel-container',
       backgroundColor: background,
-      border: `1px solid ${borderColor}`,
+      border: `${panelBorderWidth}px solid ${borderColor}`,
       // Larger corner radius + soft elevation to match the Carrot UI card language.
-      borderRadius: theme.shape.borderRadius(3),
+      borderRadius: panelBorderRadius,
       boxShadow: theme.shadows.z1,
       position: 'relative',
       height: '100%',
@@ -439,19 +454,20 @@ const getStyles = (isFNPanel?: boolean) => (theme: GrafanaTheme2) => {
     transparentContainer: css({
       label: 'panel-transparent-container',
       backgroundColor: 'transparent',
-      border: '1px solid transparent',
+      border: `${panelBorderWidth}px solid transparent`,
       boxShadow: 'none',
       boxSizing: 'border-box',
       '&:hover': {
-        border: `1px solid ${borderColor}`,
+        border: `${panelBorderWidth}px solid ${borderColor}`,
         boxShadow: theme.shadows.z1,
       },
     }),
     loadingBarContainer: css({
       label: 'panel-loading-bar-container',
-      position: 'absolute',
-      top: 0,
-      width: '100%',
+      // Overlay the flat part of the panel's top border without painting through
+      // its rounded corners. Absolute positioning is relative to the inner edge
+      // of the panel border, hence the border-width adjustment on each inset.
+      ...getPanelLoadingBarStyles(panelBorderRadius, panelBorderWidth),
       // this is to force the loading bar container to create a new stacking context
       // otherwise, in webkit browsers on windows/linux, the aliasing of panel text changes when the loading bar is shown
       // see https://github.com/grafana/grafana/issues/88104


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved panel loading indicators so they align correctly with panel borders.
  - Loading bars now account for rounded corners and border thickness, preventing overlap or visual misalignment.
  - Transparent panels display loading indicators with consistent border alignment.
  - Loading indicators now avoid rounded panel corners and remain positioned correctly across different panel layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->