### PR TITLE
fix(deps): bump golang-jwt/jwt to v4.5.2 and v5.2.2 (CVE-2025-30204)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/go-stack/stack v1.8.1 // @grafana/grafana-backend-group
 	github.com/gobwas/glob v0.2.3 // @grafana/grafana-backend-group
 	github.com/gogo/protobuf v1.3.2 // @grafana/alerting-backend
-	github.com/golang-jwt/jwt/v4 v4.5.0 // @grafana/grafana-backend-group
+	github.com/golang-jwt/jwt/v4 v4.5.2 // @grafana/grafana-backend-group
 	github.com/golang-migrate/migrate/v4 v4.7.0 // @grafana/grafana-backend-group
 	github.com/golang/mock v1.6.0 // @grafana/alerting-backend
 	github.com/golang/protobuf v1.5.4 // @grafana/grafana-backend-group
@@ -289,7 +289,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/status v1.1.1 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/glog v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2057,9 +2057,13 @@ github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-migrate/migrate/v4 v4.7.0 h1:gONcHxHApDTKXDyLH/H97gEHmpu1zcnnbAaq2zgrPrs=
 github.com/golang-migrate/migrate/v4 v4.7.0/go.mod h1:Qvut3N4xKWjoH3sokBccML6WyHSnggXm/DvMMnTsQIc=
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 h1:au07oEsX2xN0ktxqI+Sida1w446QrXBRJ0nee3SNZlA=


### PR DESCRIPTION
## Summary

Addresses [VULN-284](https://linear.app/coderabbit/issue/VULN-284/prod-multigoogleosvtrivy-high-cve-2025-30204-vulnerabilities-in) — **HIGH** severity `CVE-2025-30204` in `github.com/golang-jwt/jwt`.

The `grafana-internal` Cloud Run image (prod) ships **both** major versions of the library, and both were on vulnerable releases. Flagged by GOOGLE + OSV + TRIVY (5 findings).

## Changes

| Module | Before | After | Fixed in |
| --- | --- | --- | --- |
| `github.com/golang-jwt/jwt/v4` | `v4.5.0` | `v4.5.2` | `4.5.2` |
| `github.com/golang-jwt/jwt/v5` (indirect) | `v5.2.1` | `v5.2.2` | `5.2.2` |

Both branches had to be bumped — fixing only one leaves the other exposed in the image.

Diff is limited to `go.mod` and `go.sum` (4 added `go.sum` lines, jwt hashes only). No source changes were required; the fix is an internal parsing hardening with no API surface change.

## Vulnerability detail

`CVE-2025-30204` — excessive memory allocation when parsing the `Authorization` header. `strings.Split` on untrusted header input allocates proportional to attacker-controlled size, enabling a memory-exhaustion DoS.

## Affected call sites

Only three files import the package; all reviewed as unaffected by the upgrade:

- `pkg/services/rendering/auth.go`
- `pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go`
- `pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine_test.go`

## Verification

```
go build ./pkg/services/rendering/... ./pkg/tsdb/grafana-postgresql-datasource/...   # pass (module + workspace mode)
go test  ./pkg/services/rendering/...                                               # ok  0.698s
go test  ./pkg/tsdb/grafana-postgresql-datasource/sqleng/...                         # ok  0.569s
go mod verify                                                                        # all modules verified
```

`go.work.sum` needed no update — the workspace-mode build resolved cleanly.

## Notes

Branched from `coderabbit_micro_frontend` (the branch that deploys prod via `deploy-cloud-run-grafana-prod.yaml`) so the fix reaches the scanned image. Re-scan after the next image build should clear all 5 findings for this ticket group.

Refs: VULN-284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication-related dependencies to newer patch versions.
  * No user-facing features or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->