### PR TITLE
fix(deps): bump moby/spdystream to v0.5.1 (CVE-2026-35469)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -369,7 +369,7 @@ require (
 	github.com/mithrandie/go-file/v2 v2.1.0 // indirect
 	github.com/mithrandie/go-text v1.6.0 // indirect
 	github.com/mithrandie/ternary v1.1.1 // indirect
-	github.com/moby/spdystream v0.4.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de // indirect
 	github.com/mschoch/smat v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2749,6 +2749,8 @@ github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YO
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/spdystream v0.4.0 h1:Vy79D6mHeJJjiPdFEL2yku1kl0chZpJfZcPpb16BRl8=
 github.com/moby/spdystream v0.4.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/sys/sequential v0.5.0 h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc=
 github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
 github.com/moby/sys/user v0.1.0 h1:WmZ93f5Ux6het5iituh9x2zAG7NFY9Aqi49jjE1PaQg=


### PR DESCRIPTION
## Summary

Addresses [VULN-290](https://linear.app/coderabbit/issue/VULN-290/prod-multigoogleosvtrivy-high-cve-2026-35469-vulnerabilities-in) — **HIGH** severity `CVE-2026-35469` in `github.com/moby/spdystream`.

Flagged by GOOGLE + OSV + TRIVY (3 findings) on the `grafana-internal` prod Cloud Run service.

## Changes

| Module | Before | After | Fixed in |
| --- | --- | --- | --- |
| `github.com/moby/spdystream` (indirect) | `v0.4.0` | `v0.5.1` | `0.5.1` |

Diff is limited to `go.mod` and `go.sum`; only `spdystream` lines changed, no other module versions drifted.

## Dependency path

The package is not imported directly anywhere in the repo — it arrives transitively through the Grafana apiserver:

```
github.com/grafana/grafana/pkg/services/apiserver
  → k8s.io/kube-aggregator/pkg/apiserver
    → k8s.io/apiserver/pkg/util/proxy
      → k8s.io/apimachinery/pkg/util/httpstream/spdy
        → github.com/moby/spdystream
```

Because there are no direct call sites, the upgrade carries no API-compatibility risk for our code. The bump is safe to apply ahead of the upstream `k8s.io/*` modules catching up.

## Verification

```
go build ./pkg/...                          # pass (full backend, no errors)
go build ./pkg/services/apiserver/...       # pass in both module and workspace mode
go test  ./pkg/services/apiserver/...       # all ok (aggregator, auth/authenticator,
                                            #          auth/authorizer, endpoints/request, standalone)
go mod verify                               # all modules verified
```

`go.work.sum` needed no update — the workspace-mode build resolved cleanly.

## Notes

Branched from `coderabbit_micro_frontend`, the branch that deploys prod via `deploy-cloud-run-grafana-prod.yaml`, so the fix reaches the scanned image. Re-scan after the next image build should clear all 3 findings for this ticket group.

Follows the same approach as #233 (VULN-284).

Refs: VULN-290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an indirect dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->