### PR TITLE
fix(deps): bump go-jose/go-jose/v3 to v3.0.5 (CVE-2026-34986)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/fullstorydev/grpchan v1.1.1 // @grafana/grafana-backend-group
 	github.com/gchaincl/sqlhooks v1.3.0 // @grafana/grafana-search-and-storage
 	github.com/getkin/kin-openapi v0.127.0 // @grafana/grafana-as-code
-	github.com/go-jose/go-jose/v3 v3.0.3 // @grafana/identity-access-team
+	github.com/go-jose/go-jose/v3 v3.0.5 // @grafana/identity-access-team
 	github.com/go-kit/log v0.2.1 //  @grafana/grafana-backend-group
 	github.com/go-ldap/ldap/v3 v3.4.4 // @grafana/identity-access-team
 	github.com/go-openapi/loads v0.21.5 // @grafana/alerting-backend

--- a/go.sum
+++ b/go.sum
@@ -1922,6 +1922,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-jose/go-jose/v3 v3.0.3 h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k=
 github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v3 v3.0.5 h1:BLLJWbC4nMZOfuPVxoZIxeYsn6Nl2r1fITaJ78UQlVQ=
+github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=


### PR DESCRIPTION
## Summary

Addresses [VULN-289](https://linear.app/coderabbit/issue/VULN-289/prod-multigoogleosvtrivy-high-cve-2026-34986-vulnerabilities-in) — **HIGH** severity `CVE-2026-34986` in `github.com/go-jose/go-jose/v3`.

Flagged by GOOGLE + OSV + TRIVY on the `grafana-internal` prod Cloud Run service.

## Changes

| Module | Before | After |
| --- | --- | --- |
| `github.com/go-jose/go-jose/v3` | `v3.0.3` | `v3.0.5` |

Upgraded to `v3.0.5`, the latest release on the `v3` line. Staying on `v3` keeps the module path unchanged — moving to `v4` would be a breaking import-path migration across ~23 files and is out of scope for a security patch.

Only `v3` is present in the module graph (`gopkg.in/square/go-jose.v2` is the unrelated legacy pre-fork module), so there is no second major version to bump here.

Diff is limited to `go.mod` and `go.sum`; only `go-jose` lines changed, no other module versions drifted.

## Blast radius

Unlike the previous two dependency bumps, this package is **imported directly** and sits on the authentication path — 23 files across:

- `pkg/services/auth/jwt/` — JWT validation, key sets
- `pkg/services/auth/idimpl/` — ID token signing
- `pkg/services/signingkeys/` — signing key store
- `pkg/services/authn/clients/ext_jwt.go` — extended JWT client
- `pkg/login/social/connectors/` — Azure AD, Okta, Google OAuth
- `pkg/services/oauthtoken/`

`v3.0.3 → v3.0.5` is a patch-level bump with no API changes; the full backend build and all auth/signing-key suites pass unchanged.

## Verification

```
go build ./pkg/...                                              # pass (full backend, no errors)
go build ./pkg/services/auth/... ./pkg/services/authn/...        # pass in workspace mode too
go test  ./pkg/services/auth/... ./pkg/services/signingkeys/...  # all ok
go test  ./pkg/login/social/connectors/...                       # ok  0.752s
go test  ./pkg/services/oauthtoken/...                           # ok  1.361s
go mod verify                                                    # all modules verified
```

Passing suites: `auth/authimpl`, `auth/gcomsso`, `auth/idimpl`, `auth/jwt`, `signingkeys/signingkeysimpl`, `signingkeys/signingkeystore`, `login/social/connectors`, `oauthtoken`.

### Pre-existing failure (not caused by this PR)

`pkg/services/authn/clients` has 6 failing subtests under `TestExtendedJWT_Authenticate`. I verified these are **pre-existing** by stashing the change and re-running on unmodified `coderabbit_micro_frontend` — the identical 6 failures reproduce at `v3.0.3`.

The assertion diff is on `authn.Identity.AccessTokenClaims` being populated where the test expects `nil` (an `authlib` claims-propagation expectation), not on JOSE parsing or signature verification. Unrelated to this upgrade and left as-is.

## Notes

Branched from `coderabbit_micro_frontend`, the branch that deploys prod via `deploy-cloud-run-grafana-prod.yaml`, so the fix reaches the scanned image.

Follows #233 (VULN-284) and #234 (VULN-290).

Refs: VULN-289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal security-related dependency to a newer patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->