### PR TITLE
fix(deps): bump buger/jsonparser to v1.1.2 (CVE-2026-32285)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -248,7 +248,7 @@ require (
 	github.com/blevesearch/vellum v1.0.7 // indirect
 	github.com/blugelabs/ice v1.0.0 // indirect
 	github.com/bufbuild/protocompile v0.4.0 // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/caio/go-tdigest v3.1.0+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/centrifugal/protocol v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1657,6 +1657,8 @@ github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZ
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
+github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/bwmarrin/snowflake v0.3.0 h1:xm67bEhkKh6ij1790JB83OujPR5CzNe8QuQqAgISZN0=
 github.com/bwmarrin/snowflake v0.3.0/go.mod h1:NdZxfVWX+oR6y2K0o6qAYv6gIOP9rjG0/E9WsDpxqwE=


### PR DESCRIPTION
## Summary

Addresses [VULN-288](https://linear.app/coderabbit/issue/VULN-288/prod-multigoogleosvtrivy-high-cve-2026-32285-vulnerabilities-in) — **HIGH** severity `CVE-2026-32285` in `github.com/buger/jsonparser`.

Flagged by GOOGLE + OSV + TRIVY on the `grafana-internal` prod Cloud Run service.

## Changes

| Module | Before | After | Fixed in |
| --- | --- | --- | --- |
| `github.com/buger/jsonparser` (indirect) | `v1.1.1` | `v1.1.2` | `1.1.2` |

`v1.1.2` is the exact fix floor, so this is the minimal bump that clears the advisory. Later releases exist up to `v1.6.1`, but there's no reason to take on extra change surface for a security patch.

Diff is limited to `go.mod` and `go.sum`; only `jsonparser` lines changed, no other module versions drifted.

## Vulnerability detail

Confirmed against OSV — [GHSA-6g7g-w4f8-9c9x](https://github.com/advisories/GHSA-6g7g-w4f8-9c9x) / `GO-2026-4514`:

> The `Delete` function fails to properly validate offsets when processing malformed JSON input. This can lead to a negative slice index and a runtime panic, allowing a denial of service attack.

CWE-125 (out-of-bounds read) and CWE-129 (improper validation of array index). Affected range is `[0, 1.1.2)`.

Upstream fix: [buger/jsonparser#276](https://github.com/buger/jsonparser/pull/276) → commit `a69e7e0`, released in [v1.1.2](https://github.com/buger/jsonparser/releases/tag/v1.1.2).

## Dependency path

Not imported directly anywhere in the repo — it arrives transitively:

```
github.com/grafana/grafana/pkg/registry/apis/query/queryschema
  → github.com/grafana/grafana-plugin-sdk-go/experimental/schemabuilder
    → github.com/invopop/jsonschema
      → github.com/wk8/go-ordered-map/v2
        → github.com/buger/jsonparser
```

No direct call sites, so the upgrade carries no API-compatibility risk for our code. Note the vulnerable `Delete` path is reached only through this JSON-schema serialisation chain, not from request-handling code, which limits practical exposure — but the package still ships in the image and is reported by all three scanners.

## Verification

```
go build ./pkg/...                                # pass (full backend, no errors)
go build ./pkg/registry/apis/query/...            # pass in workspace mode too
go test  ./pkg/registry/apis/query/...            # ok  0.866s
go mod verify                                     # all modules verified
```

`queryschema` itself has no test files; the parent `query` package suite covers it and passes.

`go.work.sum` needed no update — the workspace-mode build resolved cleanly.

## Notes

Branched from `coderabbit_micro_frontend`, the branch that deploys prod via `deploy-cloud-run-grafana-prod.yaml`, so the fix reaches the scanned image.

Follows #233 (VULN-284), #234 (VULN-290) and #235 (VULN-289).

Refs: VULN-288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an indirect dependency to a newer patch version, including upstream fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->