### PR TITLE
fix(deps): bump apache/thrift to v0.23.0 (CVE-2026-41602)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG BASE_IMAGE=alpine:3.19.1
 ARG JS_IMAGE=node:20-alpine
 ARG JS_PLATFORM=linux/amd64
-ARG GO_IMAGE=golang:1.24.9-alpine
+ARG GO_IMAGE=golang:1.25.14-alpine
 
 ARG GO_SRC=go-builder
 ARG JS_SRC=js-builder

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/grafana/grafana
 
-go 1.24.0
-
-toolchain go1.24.10
+go 1.25
 
 // contains openapi encoder fixes. remove ASAP
 replace cuelang.org/go => github.com/grafana/cue v0.0.0-20230926092038-971951014e3f // @grafana/grafana-as-code
@@ -231,7 +229,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
-	github.com/apache/thrift v0.20.0 // indirect
+	github.com/apache/thrift v0.23.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1522,6 +1522,8 @@ github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2
 github.com/apache/thrift v0.17.0/go.mod h1:OLxhMRJxomX+1I/KUw03qoV3mMz16BwaKI+d4fPBx7Q=
 github.com/apache/thrift v0.20.0 h1:631+KvYbsBZxmuJjYwhezVsrfc/TbqtZV4QcxOX1fOI=
 github.com/apache/thrift v0.20.0/go.mod h1:hOk1BQqcp2OLzGsyVXdfMk7YFlMxK3aoEVhjD06QhB8=
+github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
+github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.24.0
+go 1.25
 
-toolchain go1.24.10
+toolchain go1.25.0
 
 // The `skip:golangci-lint` comment tag is used to exclude the package from the `golangci-lint` GitHub Action.
 // The module at the root of the repo (`.`) is excluded because ./pkg/... is included manually in the `golangci-lint` configuration.


### PR DESCRIPTION
## Summary

Addresses [VULN-287](https://linear.app/coderabbit/issue/VULN-287/prod-multigoogleosvtrivy-high-cve-2026-41602-vulnerabilities-in) — **HIGH** severity `CVE-2026-41602` in `github.com/apache/thrift`.

Flagged by GOOGLE + OSV + TRIVY on the `grafana-internal` prod Cloud Run service.

> ⚠️ **This one is not a one-line bump.** The fix floor requires a Go toolchain upgrade — please read the toolchain section before approving.

## Changes

| File | Before | After |
| --- | --- | --- |
| `github.com/apache/thrift` (indirect) | `v0.20.0` | `v0.23.0` |
| `go.mod` — go directive | `go 1.24.0` + `toolchain go1.24.10` | `go 1.25` |
| `go.work` — go directive | `go 1.24.0` + `toolchain go1.24.10` | `go 1.25` + `toolchain go1.25.0` |
| `Dockerfile` — `GO_IMAGE` | `golang:1.24.9-alpine` | `golang:1.25.14-alpine` |

`go.sum` changes are thrift-only; no other module versions drifted.

## Vulnerability detail

Confirmed against OSV — `GHSA-wf45-q9ch-q8gh` / `BIT-thrift-2026-41602`:

> **Apache Thrift: Go TFramedTransport uint32 overflow** — Integer Overflow or Wraparound vulnerability in Apache Thrift TFramedTransport Go language implementation. This issue affects Apache Thrift: before 0.23.0. Users are recommended to upgrade to version 0.23.0, which fixes the issue.

Affected range is `[0, 0.23.0)`, so `0.23.0` is the exact fix floor.

## Why the toolchain had to move

`thrift v0.23.0` declares `go 1.25` in its own `go.mod`. This is a **hard constraint**, not advisory — I verified it by pinning thrift to `v0.23.0` while holding the repo at `go 1.24.0`, which fails outright:

```
go: updates to go.mod needed; to update it:
        go mod tidy
```

I checked the intermediate releases to see if the toolchain bump could be avoided:

| thrift | own `go` directive | clears CVE? |
| --- | --- | --- |
| `v0.21.0` | `go 1.22.0` | ❌ |
| `v0.22.0` | `go 1.23` | ❌ |
| `v0.23.0` | `go 1.25` | ✅ |

Neither lower release clears the advisory, so Go 1.25 is unavoidable if we want this CVE closed by upgrade. `go get` bumped the `go` directive on its own; I bumped `go.work` and the Dockerfile builder image to match so local, CI, and image builds stay consistent. `golang:1.25.14-alpine` is the current latest 1.25 Alpine tag.

Per-module `toolchain go1.24.10` pins in `pkg/*/go.mod` submodules were deliberately left alone — workspace members may declare a lower toolchain than the workspace, and all of them still build.

## Dependency path

Not imported directly anywhere in the repo:

```
github.com/grafana/grafana/pkg/expr
  → github.com/scottlepp/go-duck/duck
    → github.com/apache/arrow/go/v15/parquet
      → github.com/apache/thrift/lib/go/thrift
```

We reach thrift through arrow's parquet codec, not by serving Thrift RPC, so `TFramedTransport` is not on a request-handling path — practical exposure is low. The package still ships in the image and all three scanners report it.

## Verification

```
go build ./pkg/...                                     # pass (full backend)
go build ./pkg/expr/...                                # pass (thrift consumer)
go test  ./pkg/expr/...                                # all ok — expr, classic, mathexp,
                                                       #   mathexp/parse, ml, sql
go build ./pkg/apimachinery/... ./pkg/apiserver/...    # pass
go build ./pkg/promlib/... ./pkg/aggregator/...        # pass
go build ./pkg/storage/unified/resource/...            # pass
go mod verify                                          # all modules verified
go list -m github.com/apache/thrift                    # v0.23.0
```

Workspace members were built individually to confirm the `go.work` directive bump didn't break any of them. `go.work.sum` needed no update.

## Review notes / risk

The dependency change is low-risk (transitive, no direct call sites), but the **Go 1.25 toolchain bump is repo-wide** and deserves a closer look than the previous bumps in this series:

- CI runners that pin Go independently of the Dockerfile should be double-checked — I found no `go-version` or `GO_VERSION` pins in `.github/workflows/`, only the Dockerfile `GO_IMAGE` arg, but a release pipeline outside this repo may pin its own.
- If the team would rather not move to Go 1.25 right now, the alternative is to accept/defer this CVE with the low-exposure rationale above, since no patched release exists on the 1.24-compatible line.

Happy to split the toolchain bump into its own PR if you'd prefer to land and review that separately.

Follows #233 (VULN-284), #234 (VULN-290), #235 (VULN-289) and #236 (VULN-288).

Refs: VULN-287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application’s Go build environment to Go 1.25.
  - Updated the Apache Thrift dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->