### PR TITLE
security: document CVE-2026-42151/42154 Prometheus exception (VULN-279)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,9 +2,10 @@
 
 # VULN-279 / CVE-2026-42151, CVE-2026-42154 — github.com/prometheus/prometheus
 #
-# Both advisories are fixed in Prometheus 3.5.3 (Go module v0.305.3) on the 3.5
-# LTS branch and in 3.11.3 (v0.311.3) on the current branch; the latest fixed
-# release is 3.11.3. Grafana pins Prometheus 2.52.0 (v0.52.0) via a replace
+# Both advisories are fixed from Prometheus 3.5.3 (Go module v0.305.3) on the
+# 3.5 LTS branch and from 3.11.3 (v0.311.3) on the current branch. Those are
+# the minimum patched releases per branch, not the newest available.
+# Grafana pins Prometheus 2.52.0 (v0.52.0) via a replace
 # directive, and moving to the 3.x line is a breaking major upgrade: it forces
 # an incompatible k8s.io/* bump (kube-aggregator, apiserver), a
 # grpc_health_v1.HealthServer signature change and the labels.Labels type
@@ -20,6 +21,16 @@
 #    Grafana binary at all.
 #
 # Revisit when Grafana upstream moves its Prometheus pin to the 3.x line.
+#
+# SCOPE CAVEAT: .trivyignore is global. Trivy matches by vulnerability ID only,
+# with no package or image qualifier, and the .drone.yml steps scan four images
+# (grafana/grafana:{latest,main,latest-ubuntu,main-ubuntu}) without passing
+# --ignorefile, so any .trivyignore in the working directory applies to all of
+# them. These two IDs are specific to github.com/prometheus/prometheus, which is
+# the same Go dependency in every Grafana image, so the wider scope does not
+# suppress an unrelated finding today. Trivy 0.21.0 has no per-image ignore
+# policy; scoping would need a newer Trivy with .trivyignore.yaml or separate
+# per-image ignore files. Re-scope if these IDs ever appear in another package.
 #
 # REVIEW BY 2027-03-08. Trivy's self-expiring 'exp:' suffix is deliberately not
 # used here: .drone.yml pins aquasec/trivy:0.21.0, whose ignorefile parser

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,1 +1,23 @@
 # See https://aquasecurity.github.io/trivy/v0.48/docs/configuration/filtering/#trivyignore
+
+# VULN-279 / CVE-2026-42151, CVE-2026-42154 — github.com/prometheus/prometheus
+#
+# Both advisories are fixed only in Prometheus 3.5.3 / 3.11.3 (Go module
+# v0.305.3 / v0.311.3). Grafana pins Prometheus 2.52.0 (v0.52.0) via a replace
+# directive, and moving to the 3.x line is a breaking major upgrade: it forces
+# an incompatible k8s.io/* bump (kube-aggregator, apiserver), a
+# grpc_health_v1.HealthServer signature change and the labels.Labels type
+# change, none of which are in scope for a security patch.
+#
+# Neither vulnerable code path is reachable in the Grafana binary:
+#  - CVE-2026-42151 leaks the Azure AD remote-write client_secret through the
+#    Prometheus /-/config API. Grafana does not serve /-/config and never
+#    builds a RemoteWriteConfig; storage/remote/azuread is linked only as a
+#    side effect of importing prometheus/config from the ngalert sender.
+#  - CVE-2026-42154 is a DoS on the Prometheus remote read endpoint
+#    (/api/v1/read) in prometheus/web/api, which is not linked into the
+#    Grafana binary at all.
+#
+# Revisit when Grafana upstream moves its Prometheus pin to the 3.x line.
+CVE-2026-42151
+CVE-2026-42154

--- a/.trivyignore
+++ b/.trivyignore
@@ -18,6 +18,8 @@
 #    (/api/v1/read) in prometheus/web/api, which is not linked into the
 #    Grafana binary at all.
 #
-# Revisit when Grafana upstream moves its Prometheus pin to the 3.x line.
-CVE-2026-42151
-CVE-2026-42154
+# Revisit when Grafana upstream moves its Prometheus pin to the 3.x line. The
+# exp: dates make these suppressions self-expiring, so Trivy reports them
+# again after 2027-03-08 instead of the exception persisting silently.
+CVE-2026-42151 exp:2027-03-08
+CVE-2026-42154 exp:2027-03-08

--- a/.trivyignore
+++ b/.trivyignore
@@ -2,8 +2,9 @@
 
 # VULN-279 / CVE-2026-42151, CVE-2026-42154 — github.com/prometheus/prometheus
 #
-# Both advisories are fixed only in Prometheus 3.5.3 / 3.11.3 (Go module
-# v0.305.3 / v0.311.3). Grafana pins Prometheus 2.52.0 (v0.52.0) via a replace
+# Both advisories are fixed in Prometheus 3.5.3 (Go module v0.305.3) on the 3.5
+# LTS branch and in 3.11.3 (v0.311.3) on the current branch; the latest fixed
+# release is 3.11.3. Grafana pins Prometheus 2.52.0 (v0.52.0) via a replace
 # directive, and moving to the 3.x line is a breaking major upgrade: it forces
 # an incompatible k8s.io/* bump (kube-aggregator, apiserver), a
 # grpc_health_v1.HealthServer signature change and the labels.Labels type
@@ -18,8 +19,13 @@
 #    (/api/v1/read) in prometheus/web/api, which is not linked into the
 #    Grafana binary at all.
 #
-# Revisit when Grafana upstream moves its Prometheus pin to the 3.x line. The
-# exp: dates make these suppressions self-expiring, so Trivy reports them
-# again after 2027-03-08 instead of the exception persisting silently.
-CVE-2026-42151 exp:2027-03-08
-CVE-2026-42154 exp:2027-03-08
+# Revisit when Grafana upstream moves its Prometheus pin to the 3.x line.
+#
+# REVIEW BY 2027-03-08. Trivy's self-expiring 'exp:' suffix is deliberately not
+# used here: .drone.yml pins aquasec/trivy:0.21.0, whose ignorefile parser
+# (getIgnoredIDs in pkg/result/result.go) appends the entire line as the ID, so
+# 'CVE-... exp:...' would match nothing and silently stop suppressing. 'exp:'
+# only became available in Trivy v0.31.0. Re-add it once the scanner is
+# upgraded.
+CVE-2026-42151
+CVE-2026-42154


### PR DESCRIPTION
## Summary

Addresses [VULN-279](https://linear.app/coderabbit/issue/VULN-279/prod-multigoogleosvtrivy-high-cve-2026-42151-cve-2026-42154) — **HIGH** `CVE-2026-42151` and `CVE-2026-42154` in `github.com/prometheus/prometheus`.

> 🛑 **This PR does not upgrade the dependency.** I attempted the upgrade, found it infeasible, and verified both vulnerable code paths are unreachable. This documents a scanner exception instead. **This needs a security-team decision, not just a code review.**

## Why no upgrade

Both advisories are fixed only in **Prometheus 3.5.3 / 3.11.3** (Go modules `v0.305.3` / `v0.311.3`). Grafana pins **2.52.0** (`v0.52.0`) via a `replace` directive in `go.mod` (plus a second one in `pkg/build/go.mod`).

There is no patched release on the 2.x line, so closing these by upgrade means moving to Prometheus 3.x. I tried it — bumping both replace directives to `v0.305.3` builds `pkg/expr` fine, but the full backend fails with cascading breakage:

```
pkg/storage/unified/resource/health.go:13:23: *healthServer does not implement
    HealthService (missing method List)
pkg/storage/unified/resource/health.go:22:9:  *healthServer does not implement
    grpc_health_v1.HealthServer (missing method List)
k8s.io/kube-aggregator@v0.31.0 .../remote_available_controller.go:308:98:
    not enough arguments in call to transport.SetAuthProxyHeaders
k8s.io/apiserver@v0.31.0 .../installer.go:701:3: cannot use resetFields
    (map[fieldpath.APIVersion]*fieldpath.Set) as map[fieldpath.APIVersion]fieldpath.Filter
k8s.io/apiserver@v0.31.0 .../etcd3.go:327:39: undefined: otelgrpc.UnaryClientInterceptor
pkg/services/ngalert/sender/sender.go:101:44: cannot use s.logger as *slog.Logger
    in argument to discovery.NewManager
pkg/services/ngalert/sender/sender.go:254:13: invalid argument: cannot make
    labels.Labels: type must be slice, map, or channel
```

This is a coordinated `k8s.io/*` + gRPC health + `labels.Labels` migration, not a dependency bump. A `go mod tidy` on top churned **211 module lines in `go.mod` and ~2,800 in `go.sum`**, pulling in unrelated upgrades (`azidentity` 1.7→1.10, new `moby/go-archive`, etc.). Far outside the blast radius of a security patch.

## Why the risk is acceptable

I verified neither vulnerable code path is reachable in the Grafana binary.

**CVE-2026-42151** — Azure AD remote-write `client_secret` typed as `string` instead of `Secret`, so it leaks in plaintext via the Prometheus `/-/config` HTTP API.

- Grafana does not serve `/-/config` — no match anywhere in `pkg/`.
- Grafana never constructs a `RemoteWriteConfig`/`RemoteReadConfig` — no usage in `pkg/`.
- `storage/remote/azuread` is linked only as a side effect of `pkg/services/ngalert/sender` importing `prometheus/config`. The sender itself has no `azuread` reference; it uses only `config`, `discovery` and `model/labels`.

**CVE-2026-42154** — unauthenticated DoS on the remote read endpoint `/api/v1/read`, which fails to validate the declared snappy decoded length before allocating.

- The endpoint lives in `prometheus/web/api`, which is **not linked into the Grafana binary at all** (confirmed via `go list -deps ./pkg/cmd/grafana/...`).

So the leak has no exposing endpoint and the DoS has no reachable handler.

## Changes

Appended both CVEs to the existing `.trivyignore` with the full rationale inline, following the mechanism already established in this repo (added in #88987, "CI: Add Trivy GitHub Action").

`.trivyignore` is the only file touched — no `go.mod`/`go.sum` drift.

## Verification

```
go build ./pkg/services/ngalert/sender/...       # pass
go list -deps ./pkg/cmd/grafana/... | rg prometheus/prometheus/web    # no match
rg '/-/config' pkg/                              # no match
rg 'RemoteWriteConfig|RemoteReadConfig' pkg/     # no match
git diff --stat                                  # .trivyignore only, +22
```

The attempted upgrade was fully reverted; `go.mod`, `go.sum`, `go.work.sum` and `pkg/build/go.mod` are untouched on this branch.

## Decision needed

Three options, in my order of preference:

1. **Merge this exception** (what the PR does) — accurate, documented, unblocks the ticket, and `.trivyignore` stops the recurring scanner noise.
2. **Defer in the tracker instead** — if the security team would rather not suppress in-repo, I can close this and mark VULN-279 as accepted-risk with the same evidence. Downside: it re-reports on every scan.
3. **Schedule the Prometheus 3.x migration** as its own project — the right long-term fix, but it's a multi-day coordinated `k8s.io/*` upgrade and should not ride on a CVE ticket. Realistically this lands when upstream Grafana moves its own pin.

Note this differs from the earlier bumps in this series (#233, #234, #235, #236) which were clean, and from #237 (VULN-287) where the fix was reachable via a Go toolchain bump.

Refs: VULN-279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability scan exclusion documentation for two Prometheus CVEs.
  * Clarified minimum patched versions across supported Prometheus release branches.
  * Documented the global scope of the exclusions, including their effect on Grafana images.
  * Added a caveat that the scanner does not support per-image exclusions.
  * Recorded scanner compatibility limitations, review timing, and conditions for restoring exclusions after an upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->