### PR TITLE
security: document CVE-2026-21728/28377 Tempo exception (VULN-278)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -62,8 +62,13 @@ CVE-2026-42154
 # go 1.25.7 and drags a ~250-line transitive upgrade wave into go.mod that
 # breaks grafana-plugin-sdk-go against the newer tablewriter API.
 #
-# Revisit when upstream Grafana moves its own Tempo pin. The exp: dates make
-# these suppressions self-expiring, so Trivy reports them again after
-# 2027-03-08 instead of the exception persisting silently.
-CVE-2026-21728 exp:2027-03-08
-CVE-2026-28377 exp:2027-03-08
+# Revisit when upstream Grafana moves its own Tempo pin.
+#
+# REVIEW BY 2027-03-08. Trivy's self-expiring 'exp:' suffix is deliberately not
+# used here: .drone.yml pins aquasec/trivy:0.21.0, whose ignorefile parser
+# (getIgnoredIDs in pkg/result/result.go) appends the entire line as the ID, so
+# 'CVE-... exp:...' would match nothing and silently stop suppressing. 'exp:'
+# only became available in Trivy v0.31.0. Re-add it once the scanner is
+# upgraded.
+CVE-2026-21728
+CVE-2026-28377

--- a/.trivyignore
+++ b/.trivyignore
@@ -62,6 +62,8 @@ CVE-2026-42154
 # go 1.25.7 and drags a ~250-line transitive upgrade wave into go.mod that
 # breaks grafana-plugin-sdk-go against the newer tablewriter API.
 #
-# Revisit when upstream Grafana moves its own Tempo pin.
-CVE-2026-21728
-CVE-2026-28377
+# Revisit when upstream Grafana moves its own Tempo pin. The exp: dates make
+# these suppressions self-expiring, so Trivy reports them again after
+# 2027-03-08 instead of the exception persisting silently.
+CVE-2026-21728 exp:2027-03-08
+CVE-2026-28377 exp:2027-03-08

--- a/.trivyignore
+++ b/.trivyignore
@@ -40,3 +40,28 @@
 # upgraded.
 CVE-2026-42151
 CVE-2026-42154
+
+# VULN-278 / CVE-2026-21728, CVE-2026-28377 — github.com/grafana/tempo
+#
+# Both advisories are Tempo *server* issues. Grafana pins Tempo at
+# v1.5.1-0.20240604192202-01f4bc8ac2d1 and imports exactly one package tree
+# from it: pkg/tempopb, the generated protobuf types used by the Tempo
+# datasource to talk to a remote Tempo. No Tempo server, query-frontend or
+# tempodb storage code is linked into the Grafana binary.
+#
+# Neither vulnerable code path is reachable:
+#  - CVE-2026-21728 is unbounded memory allocation on large Tempo query
+#    limits, mitigated server-side via max_result_limit. Grafana has no such
+#    config and does not run the Tempo query path.
+#  - CVE-2026-28377 leaks the S3 SSE-C encryption key via Tempo's
+#    /status/config endpoint. Grafana does not serve /status/config and never
+#    constructs Tempo S3 storage config.
+#
+# Upgrading is also not viable in isolation: Tempo stopped publishing tagged
+# Go module versions after v1.5.0, and the 2.10.3 fix commit requires
+# go 1.25.7 and drags a ~250-line transitive upgrade wave into go.mod that
+# breaks grafana-plugin-sdk-go against the newer tablewriter API.
+#
+# Revisit when upstream Grafana moves its own Tempo pin.
+CVE-2026-21728
+CVE-2026-28377

--- a/.trivyignore
+++ b/.trivyignore
@@ -64,6 +64,16 @@ CVE-2026-42154
 #
 # Revisit when upstream Grafana moves its own Tempo pin.
 #
+# SCOPE CAVEAT: .trivyignore is global. Trivy matches by vulnerability ID only,
+# with no package or image qualifier, and the .drone.yml steps scan four images
+# (grafana/grafana:{latest,main,latest-ubuntu,main-ubuntu}) without passing
+# --ignorefile, so any .trivyignore in the working directory applies to all of
+# them. These two IDs are specific to github.com/grafana/tempo, which is the
+# same Go dependency in every Grafana image, so the wider scope does not
+# suppress an unrelated finding today. Trivy 0.21.0 has no per-image ignore
+# policy; scoping would need a newer Trivy with .trivyignore.yaml or separate
+# per-image ignore files. Re-scope if these IDs ever appear in another package.
+#
 # REVIEW BY 2027-03-08. Trivy's self-expiring 'exp:' suffix is deliberately not
 # used here: .drone.yml pins aquasec/trivy:0.21.0, whose ignorefile parser
 # (getIgnoredIDs in pkg/result/result.go) appends the entire line as the ID, so


### PR DESCRIPTION
## Summary

Addresses [VULN-278](https://linear.app/coderabbit/issue/VULN-278/prod-multigoogleosvtrivy-high-cve-2026-21728-cve-2026-28377) — **HIGH** `CVE-2026-21728` and `CVE-2026-28377` in `github.com/grafana/tempo`.

> 🛑 **This PR does not upgrade the dependency.** Both advisories are Tempo **server** issues, and Grafana links only Tempo's generated protobuf types. I attempted the upgrade, found it infeasible in isolation, and verified neither path is reachable. **This needs a security-team decision, not just a code review.**

Same shape as #238 (VULN-279).

## Why the risk is acceptable

Grafana imports exactly **one** package tree from Tempo — `pkg/tempopb`, the generated protobuf types the Tempo datasource uses to talk to a *remote* Tempo instance. Confirmed via `go list -deps ./pkg/cmd/grafana/...`, the only linked packages are:

```
github.com/grafana/tempo/pkg/tempopb
github.com/grafana/tempo/pkg/tempopb/common/v1
github.com/grafana/tempo/pkg/tempopb/pool
github.com/grafana/tempo/pkg/tempopb/resource/v1
github.com/grafana/tempo/pkg/tempopb/trace/v1
```

No `modules/`, `cmd/` or `tempodb/` code is linked — we do not run a Tempo server, query-frontend, or storage backend.

**CVE-2026-21728** — unbounded memory allocation from large Tempo query limits; upstream mitigation is the server-side `max_result_limit` search config.
- Grafana has no `max_result_limit`/`MaxResultLimit` config and does not execute Tempo's query path. The allocation happens in the Tempo server we query, not in our process.

**CVE-2026-28377** — S3 SSE-C encryption key exposed in plaintext through Tempo's `/status/config` endpoint.
- Grafana does not serve `/status/config` (no match in `pkg/`) and never constructs Tempo S3 storage config (no SSE-C/SSE-KMS references).

Both are risks to a Tempo *deployment*. Our exposure as a Tempo *client* is nil.

## Why no upgrade

Two independent blockers:

1. **No tagged module version carries the fix.** Tempo stopped publishing Go module tags after `v1.5.0`; `go list -m -versions` shows nothing on a `v2.x` line, and `@latest` still resolves to `v1.5.0`. The repo already pins a pseudo-version (`v1.5.1-0.20240604192202-01f4bc8ac2d1`). The fixes land in Tempo 2.8.4/2.9.2/2.10.2 and 2.10.3 — reachable only by commit SHA.

2. **The fix commit cascades.** Pinning the 2.10.3 fix commit `4aeafc237b8d` (via `go get` or a `replace` + `go.sum` hashes) requires `go 1.25.7` and pulls a **~250-line transitive upgrade wave** into `go.mod` — `cloud.google.com/go` 0.115→0.123, `azidentity` 1.7→1.13, `apache/thrift` 0.20→0.22, and many more. That breaks the build:

```
grafana-plugin-sdk-go@v0.250.0/data/frame.go:468:8:
    table.SetAutoFormatHeaders undefined (type *tablewriter.Table has no field or method SetAutoFormatHeaders)
grafana-plugin-sdk-go@v0.250.0/data/frame.go:471:33: undefined: tablewriter.ALIGN_LEFT
grafana-plugin-sdk-go@v0.250.0/data/frame.go:482:8:
    table.SetHeader undefined (type *tablewriter.Table has no field or method SetHeader)
```

Closing this by upgrade would mean bumping `grafana-plugin-sdk-go` and the Go toolchain as well — a coordinated migration, not a security patch, and disproportionate given zero reachability.

## Changes

Appended both CVEs to `.trivyignore` with the full rationale inline, matching the mechanism used in #238 and originally added in #88987.

`.trivyignore` is the only file touched — no `go.mod`/`go.sum`/`go.work` drift.

## Verification

```
go list -deps ./pkg/cmd/grafana/... | rg 'grafana/tempo'              # only pkg/tempopb/*
go list -deps ./pkg/cmd/grafana/... | rg 'tempo/(modules|cmd|tempodb)' # no match
rg '/status/config' pkg/                                              # no match
rg 'max_result_limit|MaxResultLimit|SSE-C|SSEKMS' pkg/                # no match
go build ./pkg/tsdb/tempo/...                                         # pass
go test  ./pkg/tsdb/tempo/...                                         # ok  0.513s
git diff --stat                                                       # .trivyignore only, +25
```

All upgrade experiments were fully reverted; `go.mod`, `go.sum`, `go.work` and `go.work.sum` are untouched on this branch.

## Decision needed

1. **Merge this exception** (what the PR does) — my recommendation. Reachability is nil and the rationale is recorded next to the suppression.
2. **Defer in the tracker instead** — if the team prefers no in-repo suppression. Downside: re-reports on every scan.
3. **Bundle a Tempo + plugin-SDK + toolchain upgrade** as separate scheduled work — the eventual path, best done when upstream Grafana moves its own Tempo pin.

Series context: #233, #234, #235, #236 were clean bumps; #237 (VULN-287) needed a Go toolchain bump; #238 (VULN-279) and this one are unreachable-path exceptions.

Refs: VULN-278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated security scanner suppressions for two Prometheus and two Tempo vulnerabilities.
  - Added review timing information for the suppressions.

- **Documentation**
  - Expanded rationale covering vulnerable-path reachability, dependency upgrade constraints, scanner scope, and limitations.
  - Documented the affected CVE identifiers and guidance for reviewing or removing suppressions when conditions change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->