### PR TITLE
fix(deps): bump golang.org/x/oauth2 to v0.27.0 (CVE-2025-22868)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ require (
 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // @grafana/alerting-backend
 	golang.org/x/mod v0.28.0 // indirect; @grafana/grafana-backend-group
 	golang.org/x/net v0.46.0 // @grafana/oss-big-tent @grafana/partner-datasources
-	golang.org/x/oauth2 v0.23.0 // @grafana/identity-access-team
+	golang.org/x/oauth2 v0.27.0 // @grafana/identity-access-team
 	golang.org/x/sync v0.17.0 // @grafana/alerting-backend
 	golang.org/x/text v0.30.0 // @grafana/grafana-backend-group
 	golang.org/x/time v0.6.0 // @grafana/grafana-backend-group

--- a/go.sum
+++ b/go.sum
@@ -3710,6 +3710,8 @@ golang.org/x/oauth2 v0.18.0/go.mod h1:Wf7knwG0MPoWIMMBgFlEaSUDaKskp0dCfrlJRJXbBi
 golang.org/x/oauth2 v0.19.0/go.mod h1:vYi7skDa1x015PmRRYZ7+s1cWyPgrPiSYRe4rnsexc8=
 golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
 golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
## Summary

Addresses [VULN-292](https://linear.app/coderabbit/issue/VULN-292/prod-multigoogleosvtrivy-high-cve-2025-22868-vulnerabilities-in) — **HIGH** severity `CVE-2025-22868` in `golang.org/x/oauth2`.

Flagged by GOOGLE + OSV + TRIVY on the `grafana-internal` prod Cloud Run service.

The cleanest fix in this series: a **3-line diff**, single module, no toolchain change, no transitive drift.

## Changes

| Module | Before | After | Fixed in |
| --- | --- | --- | --- |
| `golang.org/x/oauth2` | `v0.23.0` | `v0.27.0` | `0.27.0` |

`v0.27.0` is the exact fix floor. `go.mod` +1/-1, `go.sum` +2 — verified only `oauth2` lines changed and the `go`/`toolchain` directives are untouched.

## Vulnerability detail

Confirmed against OSV — [GHSA-6v2p-p543-phr9](https://github.com/advisories/GHSA-6v2p-p543-phr9) / `GO-2025-3488`:

> **Improper Validation of Syntactic Correctness of Input** — An attacker can pass a malicious malformed token which causes unexpected memory to be consumed during parsing.

The flaw is in the JWS token parser; a malformed token drives unbounded memory consumption, enabling denial of service. Affected range is `[0, 0.27.0)`.

## Blast radius

Imported **directly** in **41 files** and sits on the authentication path — OAuth login connectors, token refresh, auth info store, plus the GCS image uploader and build tooling. Examples:

- `pkg/services/oauthtoken/`, `pkg/services/login/`, `pkg/login/social/connectors/`
- `pkg/services/auth/`, `pkg/services/login/authinfoimpl/`
- `pkg/components/imguploader/gcs/`, `pkg/ifaces/gcsifaces/`

`v0.23.0 → v0.27.0` is a patch-level bump within the same `x/` minor series with no API changes, so no source edits were required. Given the breadth and the auth-path exposure, I ran the affected suites rather than relying on the build alone.

## Verification

```
go build ./pkg/...                                   # pass (full backend)
go test  ./pkg/services/oauthtoken/...               # ok  1.522s
go test  ./pkg/services/login/...                    # ok (+ authinfoimpl)
go test  ./pkg/login/social/...                      # ok (connectors, socialimpl)
go test  ./pkg/services/auth/...                     # ok (authimpl, gcomsso, idimpl, jwt)
go test  ./pkg/components/imguploader/...             # ok (+ gcs)
go build ./pkg/apiserver/... ./pkg/aggregator/...     # pass
go build ./pkg/storage/unified/resource/... ./pkg/storage/unified/apistore/...   # pass
go mod verify                                        # all modules verified
go list -m golang.org/x/oauth2                       # v0.27.0
```

13 test packages pass, including the full `pkg/services/auth/...` tree. The four workspace submodules that pin `x/oauth2` keep their existing `// indirect` entries — the workspace resolves them all to `v0.27.0` and each still builds. `go.work.sum` needed no update.

Notably, no pre-existing failures surfaced in the auth area here, unlike #235 (VULN-289) where `TestExtendedJWT_Authenticate` was already red on the base branch.

## Notes

Branched from `coderabbit_micro_frontend`, the branch that deploys prod via `deploy-cloud-run-grafana-prod.yaml`, so the fix reaches the scanned image.

This PR touches only `go.mod`/`go.sum` and does **not** change the Go toolchain, so it has no conflict with #237 or #240 and can merge independently in any order.

Series: #233, #234, #235, #236 clean bumps; #237 bump + toolchain; #238, #239 unreachable-path exceptions; #240 bump + toolchain.

Refs: VULN-292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OAuth 2.0 dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->