### PR TITLE
fix(deps): bump goxmldsig to v1.6.0 (CVE-2026-33487)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/apache/arrow/go/v15 v15.0.2 // @grafana/observability-metrics
 	github.com/armon/go-radix v1.0.0 // @grafana/grafana-app-platform-squad
 	github.com/aws/aws-sdk-go v1.55.5 // @grafana/aws-datasources
-	github.com/beevik/etree v1.2.0 // @grafana/grafana-backend-group
+	github.com/beevik/etree v1.6.0 // @grafana/grafana-backend-group
 	github.com/benbjohnson/clock v1.3.5 // @grafana/alerting-backend
 	github.com/blang/semver/v4 v4.0.0 // indirect; @grafana/grafana-release-guild
 	github.com/blugelabs/bluge v0.1.9 // @grafana/grafana-backend-group
@@ -144,7 +144,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20221021121301-51a44e6657c3 // @grafana/alerting-backend
 	github.com/redis/go-redis/v9 v9.1.0 // @grafana/alerting-backend
 	github.com/robfig/cron/v3 v3.0.1 // @grafana/grafana-backend-group
-	github.com/russellhaering/goxmldsig v1.4.0 // @grafana/grafana-backend-group
+	github.com/russellhaering/goxmldsig v1.6.0 // @grafana/grafana-backend-group
 	github.com/scottlepp/go-duck v0.1.0 // @grafana/grafana-app-platform-squad
 	github.com/spf13/cobra v1.8.1 // @grafana/grafana-app-platform-squad
 	github.com/spf13/pflag v1.0.5 // @grafana-app-platform-squad
@@ -336,7 +336,7 @@ require (
 	github.com/jeremywohl/flatten v1.0.1 // @grafana/grafana-app-platform-squad
 	github.com/jessevdk/go-flags v1.5.0 // indirect
 	github.com/jhump/protoreflect v1.15.1 // indirect
-	github.com/jonboulle/clockwork v0.4.0 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/jszwedko/go-datemath v0.1.1-0.20230526204004-640a500621d6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1606,6 +1606,8 @@ github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3/go.mod h1:CIWtjk
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/beevik/etree v1.2.0 h1:l7WETslUG/T+xOPs47dtd6jov2Ii/8/OjCldk5fYfQw=
 github.com/beevik/etree v1.2.0/go.mod h1:aiPf89g/1k3AShMVAzriilpcE4R/Vuor90y83zVZWFc=
+github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=
+github.com/beevik/etree v1.6.0/go.mod h1:bh4zJxiIr62SOf9pRzN7UUYaEDa9HEKafK25+sLc0Gc=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -2533,6 +2535,8 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
@@ -3060,6 +3064,8 @@ github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/russellhaering/goxmldsig v1.4.0 h1:8UcDh/xGyQiyrW+Fq5t8f+l2DLB1+zlhYzkPUJ7Qhys=
 github.com/russellhaering/goxmldsig v1.4.0/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWydB7n0KkEubVJl+Tw=
+github.com/russellhaering/goxmldsig v1.6.0 h1:8fdWXEPh2k/NZNQBPFNoVfS3JmzS4ZprY/sAOpKQLks=
+github.com/russellhaering/goxmldsig v1.6.0/go.mod h1:TrnaquDcYxWXfJrOjeMBTX4mLBeYAqaHEyUeWPxZlBM=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=


### PR DESCRIPTION
## Summary

Addresses [VULN-291](https://linear.app/coderabbit/issue/VULN-291/prod-multigoogleosvtrivy-high-cve-2026-33487-vulnerabilities-in) — **HIGH** severity `CVE-2026-33487` in `github.com/russellhaering/goxmldsig`.

Flagged by GOOGLE + OSV + TRIVY on the `grafana-internal` prod Cloud Run service. Last remaining Go-module HIGH in the VULN-27x/28x/29x batch.

## Changes

| Module | Before | After |
| --- | --- | --- |
| `github.com/russellhaering/goxmldsig` | `v1.4.0` | `v1.6.0` |
| `github.com/beevik/etree` | `v1.2.0` | `v1.6.0` |
| `github.com/jonboulle/clockwork` (indirect) | `v0.4.0` | `v0.5.0` |

`v1.6.0` is the exact fix floor. `goxmldsig v1.6.0` requires `etree v1.6.0`, so `go get` pulled that and `clockwork` along with it — 9 lines total across `go.mod`/`go.sum`, no `go`/`toolchain` directive change.

## Vulnerability detail

Confirmed against OSV — [GHSA-479m-364c-43vc](https://github.com/advisories/GHSA-479m-364c-43vc) / `GO-2026-4753`:

> **validateSignature Loop Variable Capture Signature Bypass** — the `validateSignature` function in `validate.go` goes through the references in the `SignedInfo` block to find one that matches the signed element's ID. […] The code takes the address of the loop variable `_ref` instead of its value. As a result, if more than one reference matches the ID or if the loop logic is incorrect, the `ref` pointer will always end up pointing to the last element in `SignedInfo.References`.

This is a **signature-verification bypass**, not a DoS: a crafted `SignedInfo` block carrying multiple references can have its signature validated against the wrong reference. Affected range is `[0, 1.6.0)`.

Note the advisory's Go-version caveat — the loop-variable capture bites "in Go versions before 1.22, **or when `go.mod` uses an older version**". This repo declares `go 1.24.0`, so the per-iteration loop semantics introduced in Go 1.22 apply and the bug is likely not triggerable as compiled here. That lowers practical risk but does not clear the finding: the vulnerable code ships in the image, scanners flag it on version alone, and relying on a language-semantics side effect for a signature-bypass fix is not a defensible control. Upgrading is the right call.

## Blast radius

`goxmldsig` is referenced from exactly one place — a blank import in `pkg/extensions/main.go` that reserves the SAML dependency set for Enterprise builds:

```go
_ "github.com/russellhaering/goxmldsig"
```

It is nonetheless **linked into the binary** (`goxmldsig`, `goxmldsig/types`, `goxmldsig/etreeutils` all appear in `go list -deps ./pkg/cmd/grafana/...`), which is why the scanners see it. With no call sites in OSS code there is no API-compatibility risk from the bump; `etree` and `clockwork` likewise have no direct importers outside that same blank-import file.

## Verification

```
go build ./pkg/...                            # pass (full backend)
go build ./pkg/extensions/...                 # pass
go test  ./pkg/services/login/...             # ok (+ authinfoimpl)
go test  ./pkg/services/oauthtoken/...        # ok  0.806s
go mod verify                                 # all modules verified
go list -m github.com/russellhaering/goxmldsig   # v1.6.0
```

### Pre-existing failure (not caused by this PR)

`pkg/api` fails on `TestMakePluginResourceRequestContentTypeEmpty`. I verified this is **pre-existing** by stashing the change and re-running on unmodified `coderabbit_micro_frontend` — it fails identically at `goxmldsig v1.4.0`.

It is a plugin-resource-request content-type assertion with no relation to XML signing, `etree`, or `clockwork`. Unrelated to this upgrade and left as-is. (Same situation as #235, which surfaced a pre-existing `TestExtendedJWT_Authenticate` failure.)

## Notes

Branched from `coderabbit_micro_frontend`, the branch that deploys prod via `deploy-cloud-run-grafana-prod.yaml`, so the fix reaches the scanned image.

Touches only `go.mod`/`go.sum` with no toolchain change, so it has no conflict with #237 or #240 and can merge independently.

Series: #233, #234, #235, #236, #241 clean bumps; #237, #240 bump + Go 1.25 toolchain; #238, #239 unreachable-path exceptions.

Refs: VULN-291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated underlying components to newer versions, maintaining compatibility and improving overall reliability.
  - No changes to public interfaces or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->