### PR TITLE
Fix panel header title and info alignment

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -73,6 +73,46 @@ it('renders panel with title in place if prop title', () => {
   expect(screen.getByText('Test Panel Header')).toBeInTheDocument();
 });
 
+it('keeps the panel title centered when the MFE heading reset adds a bottom margin', () => {
+  const mfeReset = document.createElement('style');
+  mfeReset.textContent = '[data-grafana-mf-root] h2 { margin-bottom: 8px; }';
+  document.head.appendChild(mfeReset);
+
+  try {
+    const rendered = setup({ title: 'Test Panel Header' });
+    rendered.container.setAttribute('data-grafana-mf-root', '');
+    const heading = screen.getByText('Test Panel Header');
+    const titleClass = heading.parentElement?.classList.item(0);
+    const rules = Array.from(document.styleSheets).flatMap((sheet) => Array.from(sheet.cssRules));
+    const titleRule = rules.find(
+      (rule): rule is CSSStyleRule =>
+        rule instanceof CSSStyleRule && Boolean(titleClass && rule.selectorText.includes(`.${titleClass} h2`))
+    );
+
+    expect(titleRule?.style.getPropertyValue('margin-bottom')).toBe('0');
+    expect(titleRule?.style.getPropertyPriority('margin-bottom')).toBe('important');
+  } finally {
+    mfeReset.remove();
+  }
+});
+
+it('insets the description hover surface without changing its header footprint', () => {
+  setup({ title: 'Test Panel Header', description: 'Test panel description' });
+
+  const descriptionItem = screen.getByTestId('title-items-container').querySelector('span');
+
+  expect(descriptionItem).toBeInTheDocument();
+  expect(getComputedStyle(descriptionItem!)).toMatchObject({
+    height: '24px',
+    paddingLeft: '4px',
+    paddingRight: '4px',
+    marginTop: '4px',
+    marginRight: '4px',
+    marginBottom: '4px',
+    marginLeft: '4px',
+  });
+});
+
 // Check for backwards compatibility
 it('renders panel with a header if prop leftItems', () => {
   setup({

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -515,6 +515,10 @@ const getStyles = (isFNPanel?: boolean) => (theme: GrafanaTheme2) => {
         color: theme.colors.text.primary,
         fontWeight: theme.typography.fontWeightMedium,
         letterSpacing: '-0.01em',
+        // The MFE's scoped Sass reset has greater specificity than Text's class
+        // and is loaded after runtime Emotion styles. Limit the override to the
+        // panel title instead of weakening heading spacing across the MFE.
+        marginBottom: '0 !important',
       },
       // FN-dashboard panel titles span the full chrome width so the title
       // and the right-aligned menu line up edge-to-edge. Titles render in

--- a/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
@@ -40,6 +40,12 @@ export function PanelDescription({ description, className }: Props) {
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     description: css({
+      // Keep the icon in the same 32px layout footprint while containing its
+      // hover surface inside the panel border and header divider.
+      height: theme.spacing(theme.components.panel.headerHeight - 1),
+      padding: theme.spacing(0, 0.5),
+      margin: theme.spacing(0.5),
+
       code: {
         whiteSpace: 'normal',
         wordWrap: 'break-word',


### PR DESCRIPTION
Embedded analytics panels inherited an 8px bottom margin on their `h2` title from the MFE reset, so the title sat 4.5px above the centered info icon. The info action also painted a 32×32 hover surface directly against the card edge and header divider, visibly covering both.

This scopes the title margin correction to `PanelChrome` and keeps the info action's 32px layout footprint while insetting its painted surface to 24×24px. Other MFE headings, panel width allocation, tooltip content, and theme colors remain unchanged.

## Before — main

Mono `9450cbe71b1630c1b28ae3b78bdc0f1f6445a495`, Grafana `b47e8605516fba1c818610714510e9048ccd4a20`, main Hutch `5f9fdefc-18b7-4842-a768-c6d873f7b21f`.

<img width="680" height="150" alt="Main before: title and info icon misaligned; hover surface overlaps the card edge and divider" src="https://github.com/user-attachments/assets/d7db907b-2d81-4873-b6b5-8e9b5c0739d9" />

The title/icon center delta is 4.5px. The hover surface is 32×32px, 1px from the card's right edge and flush with the header divider.

## After — this branch

The same Mono revision and authenticated dashboard data were used with Grafana `6e477266402734bed3a528b77b9f7c011bd91514`, built inside candidate Hutch `957ab2ec-5bb4-4c91-bb33-63e6017dec5a`.

<img width="680" height="150" alt="Branch after: title and info icon aligned; hover surface contained inside the card" src="https://github.com/user-attachments/assets/63e7d3aa-75f9-4300-a7ed-a7008b767cca" />

The title/icon center delta is reduced to the 0.5px text-rasterization offset. The hover surface is 24×24px with 5px clearance from the card edge and 4px from the divider.

## Impact and validation

- Measured all 15 description-bearing panels on PR Reviews Summary: every candidate header has the same corrected center and containment geometry.
- Navigated the same candidate MFE instance to IDE/CLI Summary: all 9 description-bearing panels passed, including a 211px narrow card and long titles; the tooltip still opens with its original content.
- Both new regression tests fail against the pinned Grafana baseline and pass on this branch.
- Relevant `PanelChrome` suite: 24 passed. The remaining full-file menu-hover failure is pre-existing and reproduces on the baseline.
- `grafana-ui` TypeScript checks, package build, Prettier, and `git diff --check` pass.
- Focused ESLint has the same two pre-existing `transition` reduction findings on baseline and candidate; this diff adds none.
- The candidate browser trace records real 200 responses for the Grafana dashboard and datasource requests. Only the MFE index/build assets were supplied by the exact candidate image; no DOM or CSS was injected.
