### PR TITLE
fix(docker): default BINGO=false to unblock image build on Go 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,11 @@ ARG COMMIT_SHA=""
 ARG BUILD_BRANCH=""
 ARG GO_BUILD_TAGS="oss"
 ARG WIRE_TAGS="oss"
-ARG BINGO="true"
+# BINGO=false by default: the image build only runs `make build-go`, which needs
+# no .bingo-managed tool. Building them all pulled golangci-lint v1.60.1, whose
+# golang.org/x/tools v0.24.0 fails to compile on Go >= 1.25 (invalid array length
+# in internal/tokeninternal). Set BINGO=true only where those tools are needed.
+ARG BINGO="false"
 
 RUN if grep -i -q alpine /etc/issue; then \
       apk add --no-cache \


### PR DESCRIPTION
## Summary

Fixes the prod deploy failure in [run 34357457417](https://github.com/coderabbitai/grafana/actions/runs/34357457417/job/102485665894).

**Yes — it is a bingo error.** But bingo is the messenger, not the cause. The trigger is the Go 1.25 bump, as suspected. The fix is *not* in the Go version, though — read on.

## The failure

Job `build_and_deploy`, step 5 `Build image once`:

```
#48 [go-builder 17/29] RUN if [[ "true" = "true" ]]; then
      go install github.com/bwplotka/bingo@latest && bingo get -v; fi

get: 0: getting github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1:
install: build versioned: # golang.org/x/tools/internal/tokeninternal
/go/pkg/mod/golang.org/x/tools@v0.24.0/internal/tokeninternal/tokeninternal.go:64:9:
  invalid array length -delta * delta (constant -256 of type int64)

ERROR: failed to build: failed to solve: process "/bin/sh -c if [[ \"$BINGO\" = \"true\" ]] ..."
  did not complete successfully: exit code: 1
```

Everything before it passed. `make build-go` was never reached.

## Root cause

`bingo get -v` builds **every** tool in `.bingo/`, including `golangci-lint v1.60.1`, which pins `golang.org/x/tools v0.24.0`. That version contains a deliberate compile-time assertion on the layout of `token.FileSet`:

```go
// x/tools@v0.24.0/internal/tokeninternal/tokeninternal.go
// If the size of token.FileSet changes, this will fail to compile.
const delta = int64(unsafe.Sizeof(tokenFileSet{})) - int64(unsafe.Sizeof(token.FileSet{}))
var _ [-delta * delta]int
```

The comment above it says the layout "remained essentially consistent from go1.16 to go1.21". Go 1.25 changed it, so `delta != 0`, `-delta * delta` is negative, and the array declaration is a compile error. It is an intentional tripwire firing exactly as designed — that `x/tools` is simply too old for this compiler.

**Why now:** the builder image moved to Go 1.25 in the CVE fixes — `GO_IMAGE golang:1.24.9-alpine` -> `golang:1.25.14-alpine` (#237 for CVE-2026-41602, #240 for CVE-2026-24051/39883). The failing commit `a94cde388af` contains those merges.

Reproduced locally on Go 1.26.5, independent of Docker:

```
$ go build github.com/golangci/golangci-lint/cmd/golangci-lint   # v1.60.1
x/tools@v0.24.0/internal/tokeninternal/tokeninternal.go:64:9:
  invalid array length -delta * delta (constant -256 of type int64)
```

## On the suspected Dockerfile Go version

Worth stating plainly, since this was the initial hypothesis: **the Dockerfile Go version is already correct and should not be reverted.**

- `golang:1.25.14-alpine` is *required* — `apache/thrift v0.23.0` and `otel/sdk v1.43.0` both declare `go 1.25`, and those are the CVE fixes.
- Grafana's own code compiles cleanly on 1.25. I verified the full backend build and the `grafana-server`/`grafana-cli` binaries before those PRs merged.
- The only thing that cannot compile on 1.25 is an **unrelated lint tool that the image never uses.**

So the Go version does not need changing. What needs changing is building a dev tool inside a release image.

## The fix

```diff
-ARG BINGO="true"
+# BINGO=false by default: the image build only runs `make build-go`, which needs
+# no .bingo-managed tool. Building them all pulled golangci-lint v1.60.1, whose
+# golang.org/x/tools v0.24.0 fails to compile on Go >= 1.25 (invalid array length
+# in internal/tokeninternal). Set BINGO=true only where those tools are needed.
+ARG BINGO="false"
```

The image build's only Go step is `RUN make build-go`, which is `gen-go` + `update-workspace` + `build.go build`. None of them invoke a `.bingo` binary — I checked each target. Every `.bingo` tool (`golangci-lint`, `bra`, `cue`, `drone`, `jb`, `lefthook`) is a dev/CI tool referenced only by targets like `golangci-lint:`, `run:` and `fix-cue:`, none of which run here.

Building six tools we never use was pure overhead that added failure surface. This removes it. `--build-arg BINGO=true` still works for anyone who needs them.

Bonus: the deleted step took **~2.5 minutes** of build time (`#48 133.2`).

## Verification

```
$ docker build --target go-builder -t grafana-gobuilder-test .
#23 [go-builder 17/29] RUN if [[ "false" = "true" ]]; then ... fi     # skipped
#35 [go-builder 29/29] RUN make build-go GO_BUILD_TAGS=oss WIRE_TAGS=oss
#36 naming to docker.io/library/grafana-gobuilder-test:latest done
BUILD_EXIT=0
```

Binaries confirmed present in the resulting stage:

```
/tmp/grafana/bin/linux-arm64/grafana          225005656
/tmp/grafana/bin/linux-arm64/grafana-cli        1829510
/tmp/grafana/bin/linux-arm64/grafana-server     1829510
```

No `go.mod`, `go.sum` or application code touched — `Dockerfile` only, +5/-1.

## Follow-up worth tracking separately

`.bingo/golangci-lint.mod` is still pinned to `v1.60.1` with `go 1.22.1`. This PR stops that breaking the *image* build, but the pin is now stale relative to the toolchain and will break local `make golangci-lint` on a Go 1.25+ machine.

Upgrading is not a drop-in: golangci-lint is on **v2.x** now (latest `v2.13.2`), and v2 changed the config schema, so `.golangci.yml` would need migrating. That is a separate change from a deploy hotfix — happy to open it if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container build to use the standard Go build process.
  * Optional Bingo-managed tooling installation now requires explicitly enabling the related build setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->