### PR TITLE
fix(docker): move base image to supported alpine:3.23 for VULN-233

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMAGE=alpine:3.19.1
+# alpine:3.19.1 shipped openssl 3.1.4-r5, flagged CRITICAL for CVE-2024-5535
+# (fix >= 3.1.6-r0) and CVE-2026-31789 on the deployed grafana-internal image
+# (VULN-233). 3.19.9 is the latest patch release on the same 3.19 branch and
+# carries openssl 3.1.8-r1, so this stays a patch-level bump with no Alpine
+# minor-version churn. Re-pin to the newest 3.19.x when bumping.
+ARG BASE_IMAGE=alpine:3.19.9
 ARG JS_IMAGE=node:20-alpine
 ARG JS_PLATFORM=linux/amd64
 ARG GO_IMAGE=golang:1.25.14-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
 # syntax=docker/dockerfile:1
 
 # alpine:3.19.1 shipped openssl 3.1.4-r5, flagged CRITICAL for CVE-2024-5535
-# (fix >= 3.1.6-r0) and CVE-2026-31789 on the deployed grafana-internal image
-# (VULN-233). 3.19.9 is the latest patch release on the same 3.19 branch and
-# carries openssl 3.1.8-r1, so this stays a patch-level bump with no Alpine
-# minor-version churn. Re-pin to the newest 3.19.x when bumping.
-ARG BASE_IMAGE=alpine:3.19.9
+# on the deployed grafana-internal image (VULN-233).
+#
+# Alpine 3.19 reached end of support on 2025-11-01 and is now "on request"
+# only, so it receives no routine security updates. It also has no fixed
+# openssl package for CVE-2026-31789 -- that fix landed upstream in 3.0.20 /
+# 3.3.7 / 3.4.5 / 3.5.6+, none of which are backported to the 3.19 branch.
+# Staying on 3.19 therefore cannot resolve VULN-233 in full.
+#
+# 3.23 is a supported branch (EOL 2027-11-01) carrying openssl 3.5.x, which is
+# past the CVE-2026-31789 fix. Pinning the branch tag rather than a patch tag
+# keeps this on the newest published 3.23.x.
+ARG BASE_IMAGE=alpine:3.23
 ARG JS_IMAGE=node:20-alpine
 ARG JS_PLATFORM=linux/amd64
 ARG GO_IMAGE=golang:1.25.14-alpine
@@ -133,7 +140,13 @@ ENV PATH="/usr/share/grafana/bin:$PATH" \
 WORKDIR $GF_PATHS_HOME
 
 # Install dependencies
+#
+# `apk upgrade` is deliberate: the published alpine:3.23 image lags its own
+# repository, so it still ships openssl 3.5.7-r0 while 3.23-main already has
+# 3.5.8-r0 (fixes CVE-2026-14456). Upgrading here picks up whatever the branch
+# has published at build time instead of pinning to the image snapshot.
 RUN if grep -i -q alpine /etc/issue; then \
+      apk upgrade --no-cache && \
       apk add --no-cache ca-certificates bash curl tzdata musl-utils && \
       apk info -vv | sort; \
     elif grep -i -q ubuntu /etc/issue; then \


### PR DESCRIPTION
## Summary

Fixes [VULN-233](https://linear.app/coderabbit/issue/VULN-233/prod-multigoogletrivy-critical-cve-2024-5535-cve-2026-31789) at the source — CRITICAL `openssl` findings (CVE-2024-5535, CVE-2026-31789) on the deployed **grafana-internal** Cloud Run service.

> **Revised after review.** The first version of this PR bumped to `alpine:3.19.9`. That was wrong on two counts — see [Correction](#correction) below. It now moves to a supported Alpine branch.

## Root cause

`gcr.io/coderabbitprod/grafana-base:latest` is built from this repo's root `Dockerfile` (via `deploy-cloud-run-grafana-prod.yaml`, triggered on `coderabbit_micro_frontend`). It pinned `ARG BASE_IMAGE=alpine:3.19.1`, which ships openssl **3.1.4-r5** — exactly the reported version:

```
$ docker run --rm gcr.io/coderabbitprod/grafana-base:latest sh -c \
    'cat /etc/alpine-release; apk list -I | grep -E "^(libssl3|libcrypto3)-3"'
3.19.1
libcrypto3-3.1.4-r5
libssl3-3.1.4-r5
```

## Correction

Staying on the 3.19 branch could not resolve this ticket:

1. **`openssl 3.1.8-r1` does not fix CVE-2026-31789.** Alpine's tracker records exactly one `fixed: true` state for that CVE — `openssl 3.5.6-r0` on **edge-main**. All 3.19-main entries are `fixed: false`. Upstream fixed it in 3.0.20 / 3.3.7 / 3.4.5 / 3.5.6+, none backported to the 3.1.x line 3.19 ships.
2. **Alpine 3.19 is end-of-life.** EOL was 2025-11-01; support level is now "on request", so no routine security updates.

## The fix

```dockerfile
ARG BASE_IMAGE=alpine:3.23   # supported until 2027-11-01, openssl 3.5.x
```

Plus `apk upgrade --no-cache` in the runtime dependency layer. That second part is necessary: the published `alpine:3.23` image lags its own repo, shipping openssl **3.5.7-r0** while `3.23-main` has **3.5.8-r0** (fixes CVE-2026-14456). Upgrading at build time tracks the branch instead of freezing on the image snapshot.

## Verification

I grafted the real grafana binary from the current prod base image onto the new runtime and ran it — not just a package-version diff:

```
grafana-server -v            → 11.3.0-pre, clean
grafana server               → HTTP 200 /api/health, {"database":"ok"}
glibc-compat 2.35-r0         → installs, loader in place
libssl3 / libcrypto3         → 3.5.8-r0
trivy CRITICAL,HIGH (OS)     → 0 findings
```

Base-image comparison (Trivy 0.74.0, OS packages, CRITICAL/HIGH):

| | alpine:3.19.1 (before) | alpine:3.19.9 (rejected) | **alpine:3.23 + upgrade** |
|---|---|---|---|
| openssl | 3.1.4-r5 — CVE-2024-5535, CVE-2024-6119 | 3.1.8-r1 — **CVE-2026-31789 unfixed** | **3.5.8-r0 — clear** |
| musl | CVE-2025-26519, CVE-2026-40200 | CVE-2026-40200 | **clear** |
| Branch support | EOL 2025-11-01 | EOL 2025-11-01 | **until 2027-11-01** |
| **Total** | 6 | 2 | **0** |

The musl 1.2.4 → 1.2.5 move is ABI-compatible and clears the musl CVEs 3.19 structurally could not.

## Rollout

Merging to `coderabbit_micro_frontend` triggers `deploy-cloud-run-grafana-prod.yaml`, rebuilding and pushing `grafana-base:latest`. `grafana-internal` in `coderabbitai/mono` then picks up patched openssl on its next build — no change needed there. Since it pins `:latest` with no digest, a `grafana-internal` deploy is required for the finding to clear in prod.

## Note for reviewers

This is a base-image branch move (3.19 → 3.23), not a patch bump, so it deserves a closer look than the original. The runtime layer is verified working, but **CI should exercise the full multi-stage build** (yarn + Go compile) before merge — I verified the runtime stage and the real binary locally, but did not complete a full end-to-end image build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated the underlying Alpine Linux base image to Alpine 3.23, including newer OpenSSL security fixes.
  * Alpine-based builds now apply current package updates before installing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->